### PR TITLE
stop paused pipeline processes

### DIFF
--- a/pipelines/syncer.go
+++ b/pipelines/syncer.go
@@ -63,6 +63,10 @@ func (syncer *Syncer) Sync() {
 
 		var found bool
 		for _, pipeline := range pipelines {
+			if pipeline.Paused {
+				continue
+			}
+
 			if pipeline.Name == name {
 				found = true
 			}
@@ -74,7 +78,7 @@ func (syncer *Syncer) Sync() {
 	}
 
 	for _, pipeline := range pipelines {
-		if syncer.isPipelineRunning(pipeline.Name) {
+		if pipeline.Paused || syncer.isPipelineRunning(pipeline.Name) {
 			continue
 		}
 


### PR DESCRIPTION
currently, paused pipelines still have a running radar and scheduler, which
causes a lot of noise in the logs.

the radar and scheduler are correct to do their own paused checks, since
they're actually doing work. this just makes it so they eventually go away
altogether (and come back once unpaused).

[#94972102]