### PR TITLE
remove massive constraint that exceeded pg limit

### DIFF
--- a/db/migrations/78_make_container_identifiers_unique.go
+++ b/db/migrations/78_make_container_identifiers_unique.go
@@ -3,9 +3,19 @@ package migrations
 import "github.com/BurntSushi/migration"
 
 func MakeContainerIdentifiersUnique(tx migration.LimitedTx) error {
-	_, err := tx.Exec(`
-		ALTER TABLE containers ADD UNIQUE
-		(worker_name, resource_id, check_type, check_source, build_id, plan_id, stage)
-	`)
-	return err
+	// This migration used to run the following, which led to errors from
+	// postgres as the resulting data for maintaining the index was too large:
+
+	// _, err := tx.Exec(`
+	// 	ALTER TABLE containers ADD UNIQUE
+	// 	(worker_name, resource_id, check_type, check_source, build_id, plan_id, stage)
+	// `)
+	// return err
+
+	// The error was:
+	//
+	//   index row size 3528 exceeds maximum 2712 for index
+	//   "containers_worker_name_resource_id_check_type_check_source__key"`
+
+	return nil
 }

--- a/db/migrations/79_clean_up_massive_unique_constraint.go
+++ b/db/migrations/79_clean_up_massive_unique_constraint.go
@@ -1,0 +1,11 @@
+package migrations
+
+import "github.com/BurntSushi/migration"
+
+func CleanUpMassiveUniqueConstraint(tx migration.LimitedTx) error {
+	_, err := tx.Exec(`
+		ALTER TABLE containers
+		DROP CONSTRAINT IF EXISTS containers_worker_name_resource_id_check_type_check_source__key
+	`)
+	return err
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -81,4 +81,5 @@ var Migrations = []migration.Migrator{
 	AddStageToContainers,
 	AddImageResourceVersions,
 	MakeContainerIdentifiersUnique,
+	CleanUpMassiveUniqueConstraint,
 }


### PR DESCRIPTION
* comment-out existing migration so folks can upgrade "through" it
* add migration after that drops the constraint if it exists, for
  deployments that were able to run it