### PR TITLE
Attempt to create container on another worker if an error occurs

### DIFF
--- a/exec/task_step.go
+++ b/exec/task_step.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -180,72 +181,13 @@ func (step *TaskStep) Run(signals <-chan os.Signal, ready chan<- struct{}) error
 			workerSpec.ResourceType = config.ImageResource.Type
 		}
 
+		var inputsToStream []inputPair
 		compatibleWorkers, err := step.workerPool.AllSatisfying(workerSpec, step.resourceTypes)
 		if err != nil {
 			return err
 		}
 
-		chosenWorker, inputMounts, inputsToStream, err := step.chooseWorkerWithMostVolumes(compatibleWorkers, config.Inputs)
-		if err != nil {
-			return err
-		}
-
-		outputMounts := []worker.VolumeMount{}
-		for _, output := range config.Outputs {
-			path := artifactsPath(output, step.artifactsRoot)
-
-			baggageclaimClient, found := chosenWorker.VolumeManager()
-			if !found {
-				break
-			}
-
-			ourVolume, volErr := baggageclaimClient.CreateVolume(step.logger, baggageclaim.VolumeSpec{
-				Properties: baggageclaim.VolumeProperties{},
-				TTL:        5 * time.Minute,
-				Privileged: bool(step.privileged),
-			})
-			if volErr != nil {
-				return volErr
-			}
-
-			outputMounts = append(outputMounts, worker.VolumeMount{
-				Volume:    ourVolume,
-				MountPath: path,
-			})
-		}
-
-		containerSpec := worker.TaskContainerSpec{
-			Platform:             config.Platform,
-			Tags:                 step.tags,
-			Privileged:           bool(step.privileged),
-			Inputs:               inputMounts,
-			Outputs:              outputMounts,
-			ImageResourcePointer: config.ImageResource,
-			Image:                config.Image,
-		}
-
-		step.container, err = chosenWorker.CreateContainer(
-			step.logger.Session("created-container"),
-			signals,
-			step.delegate,
-			runContainerID,
-			step.metadata,
-			containerSpec,
-			step.resourceTypes,
-		)
-
-		for _, mount := range inputMounts {
-			// stop heartbeating ourselves now that container has picked up the
-			// volumes
-			mount.Volume.Release(nil)
-		}
-
-		for _, mount := range outputMounts {
-			// stop heartbeating ourselves now that container has picked up the
-			// volumes
-			mount.Volume.Release(nil)
-		}
-
+		step.container, inputsToStream, err = step.createContainer(compatibleWorkers, config, signals)
 		if err != nil {
 			return err
 		}
@@ -324,6 +266,89 @@ func (step *TaskStep) Run(signals <-chan os.Signal, ready chan<- struct{}) error
 	case err := <-waitErr:
 		return err
 	}
+}
+
+func (step *TaskStep) createContainer(compatibleWorkers []worker.Worker, config atc.TaskConfig, signals <-chan os.Signal) (worker.Container, []inputPair, error) {
+	chosenWorker, inputMounts, inputsToStream, err := step.chooseWorkerWithMostVolumes(compatibleWorkers, config.Inputs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	outputMounts := []worker.VolumeMount{}
+	for _, output := range config.Outputs {
+		path := artifactsPath(output, step.artifactsRoot)
+
+		baggageclaimClient, found := chosenWorker.VolumeManager()
+		if !found {
+			break
+		}
+
+		ourVolume, volErr := baggageclaimClient.CreateVolume(step.logger, baggageclaim.VolumeSpec{
+			Properties: baggageclaim.VolumeProperties{},
+			TTL:        5 * time.Minute,
+			Privileged: bool(step.privileged),
+		})
+		if volErr != nil {
+			return nil, nil, volErr
+		}
+
+		outputMounts = append(outputMounts, worker.VolumeMount{
+			Volume:    ourVolume,
+			MountPath: path,
+		})
+	}
+
+	containerSpec := worker.TaskContainerSpec{
+		Platform:             config.Platform,
+		Tags:                 step.tags,
+		Privileged:           bool(step.privileged),
+		Inputs:               inputMounts,
+		Outputs:              outputMounts,
+		ImageResourcePointer: config.ImageResource,
+		Image:                config.Image,
+	}
+
+	runContainerID := step.containerID
+	runContainerID.Stage = db.ContainerStageRun
+	container, err := chosenWorker.CreateContainer(
+		step.logger.Session("created-container"),
+		signals,
+		step.delegate,
+		runContainerID,
+		step.metadata,
+		containerSpec,
+		step.resourceTypes,
+	)
+
+	if err != nil {
+		step.logger.Info(err.Error())
+		var newCompatibleWorkers []worker.Worker
+		for _, worker := range compatibleWorkers {
+			if worker != chosenWorker {
+				newCompatibleWorkers = append(newCompatibleWorkers, worker)
+			}
+		}
+
+		if len(newCompatibleWorkers) == 0 {
+			return nil, nil, errors.New("failed to create container on all compatible workers")
+		}
+
+		return step.createContainer(newCompatibleWorkers, config, signals)
+	}
+
+	for _, mount := range inputMounts {
+		// stop heartbeating ourselves now that container has picked up the
+		// volumes
+		mount.Volume.Release(nil)
+	}
+
+	for _, mount := range outputMounts {
+		// stop heartbeating ourselves now that container has picked up the
+		// volumes
+		mount.Volume.Release(nil)
+	}
+
+	return container, inputsToStream, nil
 }
 
 func (step *TaskStep) registerSource(config atc.TaskConfig) {

--- a/exec/task_step_test.go
+++ b/exec/task_step_test.go
@@ -1274,13 +1274,13 @@ var _ = Describe("GardenFactory", func() {
 						})
 
 						It("exits with the error", func() {
-							Eventually(process.Wait()).Should(Receive(Equal(errors.New("Failed to create container on all compatible workers"))))
+							Eventually(process.Wait()).Should(Receive(MatchError("failed to create container on all compatible workers")))
 						})
 
 						It("invokes the delegate's Failed callback", func() {
 							process.Wait()
 							Expect(taskDelegate.FailedCallCount()).To(Equal(1))
-							Expect(taskDelegate.FailedArgsForCall(0)).To(Equal(errors.New("Failed to create container on all compatible workers")))
+							Expect(taskDelegate.FailedArgsForCall(0)).To(MatchError("failed to create container on all compatible workers"))
 						})
 					})
 				})
@@ -1432,9 +1432,9 @@ var _ = Describe("GardenFactory", func() {
 									})
 
 									It("exits and invokes the delegate's Failed callback", func() {
-										Eventually(process.Wait()).Should(Receive(Equal(errors.New("Failed to create container on all compatible workers"))))
+										Eventually(process.Wait()).Should(Receive(MatchError("failed to create container on all compatible workers")))
 										Expect(taskDelegate.FailedCallCount()).To(Equal(1))
-										Expect(taskDelegate.FailedArgsForCall(0)).To(Equal(errors.New("Failed to create container on all compatible workers")))
+										Expect(taskDelegate.FailedArgsForCall(0)).To(MatchError("failed to create container on all compatible workers"))
 									})
 								})
 							})


### PR DESCRIPTION
MicroPCF team requires this in order to limit the number of containers in our custom Houdini workers.

We think this is a generally useful behavior. Failed attempts to create containers are logged.