### PR TITLE
Set identifying info for check container

### DIFF
--- a/api/jobserver/create_build.go
+++ b/api/jobserver/create_build.go
@@ -33,7 +33,7 @@ func (s *Server) CreateJobBuild(pipelineDB db.PipelineDB) http.Handler {
 			return
 		}
 
-		scheduler := s.schedulerFactory.BuildScheduler(pipelineDB)
+		scheduler := s.schedulerFactory.BuildScheduler(pipelineDB, s.externalURL)
 
 		build, _, err := scheduler.TriggerImmediately(logger, job, config.Resources, config.ResourceTypes)
 		if err != nil {

--- a/api/jobserver/fakes/fake_scheduler_factory.go
+++ b/api/jobserver/fakes/fake_scheduler_factory.go
@@ -10,24 +10,26 @@ import (
 )
 
 type FakeSchedulerFactory struct {
-	BuildSchedulerStub        func(db.PipelineDB) scheduler.BuildScheduler
+	BuildSchedulerStub        func(db.PipelineDB, string) scheduler.BuildScheduler
 	buildSchedulerMutex       sync.RWMutex
 	buildSchedulerArgsForCall []struct {
 		arg1 db.PipelineDB
+		arg2 string
 	}
 	buildSchedulerReturns struct {
 		result1 scheduler.BuildScheduler
 	}
 }
 
-func (fake *FakeSchedulerFactory) BuildScheduler(arg1 db.PipelineDB) scheduler.BuildScheduler {
+func (fake *FakeSchedulerFactory) BuildScheduler(arg1 db.PipelineDB, arg2 string) scheduler.BuildScheduler {
 	fake.buildSchedulerMutex.Lock()
 	fake.buildSchedulerArgsForCall = append(fake.buildSchedulerArgsForCall, struct {
 		arg1 db.PipelineDB
-	}{arg1})
+		arg2 string
+	}{arg1, arg2})
 	fake.buildSchedulerMutex.Unlock()
 	if fake.BuildSchedulerStub != nil {
-		return fake.BuildSchedulerStub(arg1)
+		return fake.BuildSchedulerStub(arg1, arg2)
 	} else {
 		return fake.buildSchedulerReturns.result1
 	}
@@ -39,10 +41,10 @@ func (fake *FakeSchedulerFactory) BuildSchedulerCallCount() int {
 	return len(fake.buildSchedulerArgsForCall)
 }
 
-func (fake *FakeSchedulerFactory) BuildSchedulerArgsForCall(i int) db.PipelineDB {
+func (fake *FakeSchedulerFactory) BuildSchedulerArgsForCall(i int) (db.PipelineDB, string) {
 	fake.buildSchedulerMutex.RLock()
 	defer fake.buildSchedulerMutex.RUnlock()
-	return fake.buildSchedulerArgsForCall[i].arg1
+	return fake.buildSchedulerArgsForCall[i].arg1, fake.buildSchedulerArgsForCall[i].arg2
 }
 
 func (fake *FakeSchedulerFactory) BuildSchedulerReturns(result1 scheduler.BuildScheduler) {

--- a/api/jobserver/server.go
+++ b/api/jobserver/server.go
@@ -9,7 +9,7 @@ import (
 //go:generate counterfeiter . SchedulerFactory
 
 type SchedulerFactory interface {
-	BuildScheduler(db.PipelineDB) scheduler.BuildScheduler
+	BuildScheduler(db.PipelineDB, string) scheduler.BuildScheduler
 }
 
 type Server struct {

--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -691,7 +691,7 @@ func (cmd *ATCCommand) constructPipelineSyncer(
 					radar.NewRunner(
 						logger.Session(pipelineDB.ScopedName("radar")),
 						cmd.Developer.Noop,
-						radarSchedulerFactory.BuildRadar(pipelineDB),
+						radarSchedulerFactory.BuildRadar(pipelineDB, cmd.ExternalURL.String()),
 						pipelineDB,
 						1*time.Minute,
 					),
@@ -703,7 +703,7 @@ func (cmd *ATCCommand) constructPipelineSyncer(
 
 						DB: pipelineDB,
 
-						Scheduler: radarSchedulerFactory.BuildScheduler(pipelineDB),
+						Scheduler: radarSchedulerFactory.BuildScheduler(pipelineDB, cmd.ExternalURL.String()),
 
 						Noop: cmd.Developer.Noop,
 

--- a/pipelines/fakes/fake_radar_scheduler_factory.go
+++ b/pipelines/fakes/fake_radar_scheduler_factory.go
@@ -11,32 +11,35 @@ import (
 )
 
 type FakeRadarSchedulerFactory struct {
-	BuildRadarStub        func(pipelineDB db.PipelineDB) *radar.Radar
+	BuildRadarStub        func(pipelineDB db.PipelineDB, externalURL string) *radar.Radar
 	buildRadarMutex       sync.RWMutex
 	buildRadarArgsForCall []struct {
-		pipelineDB db.PipelineDB
+		pipelineDB  db.PipelineDB
+		externalURL string
 	}
 	buildRadarReturns struct {
 		result1 *radar.Radar
 	}
-	BuildSchedulerStub        func(pipelineDB db.PipelineDB) scheduler.BuildScheduler
+	BuildSchedulerStub        func(pipelineDB db.PipelineDB, externalURL string) scheduler.BuildScheduler
 	buildSchedulerMutex       sync.RWMutex
 	buildSchedulerArgsForCall []struct {
-		pipelineDB db.PipelineDB
+		pipelineDB  db.PipelineDB
+		externalURL string
 	}
 	buildSchedulerReturns struct {
 		result1 scheduler.BuildScheduler
 	}
 }
 
-func (fake *FakeRadarSchedulerFactory) BuildRadar(pipelineDB db.PipelineDB) *radar.Radar {
+func (fake *FakeRadarSchedulerFactory) BuildRadar(pipelineDB db.PipelineDB, externalURL string) *radar.Radar {
 	fake.buildRadarMutex.Lock()
 	fake.buildRadarArgsForCall = append(fake.buildRadarArgsForCall, struct {
-		pipelineDB db.PipelineDB
-	}{pipelineDB})
+		pipelineDB  db.PipelineDB
+		externalURL string
+	}{pipelineDB, externalURL})
 	fake.buildRadarMutex.Unlock()
 	if fake.BuildRadarStub != nil {
-		return fake.BuildRadarStub(pipelineDB)
+		return fake.BuildRadarStub(pipelineDB, externalURL)
 	} else {
 		return fake.buildRadarReturns.result1
 	}
@@ -48,10 +51,10 @@ func (fake *FakeRadarSchedulerFactory) BuildRadarCallCount() int {
 	return len(fake.buildRadarArgsForCall)
 }
 
-func (fake *FakeRadarSchedulerFactory) BuildRadarArgsForCall(i int) db.PipelineDB {
+func (fake *FakeRadarSchedulerFactory) BuildRadarArgsForCall(i int) (db.PipelineDB, string) {
 	fake.buildRadarMutex.RLock()
 	defer fake.buildRadarMutex.RUnlock()
-	return fake.buildRadarArgsForCall[i].pipelineDB
+	return fake.buildRadarArgsForCall[i].pipelineDB, fake.buildRadarArgsForCall[i].externalURL
 }
 
 func (fake *FakeRadarSchedulerFactory) BuildRadarReturns(result1 *radar.Radar) {
@@ -61,14 +64,15 @@ func (fake *FakeRadarSchedulerFactory) BuildRadarReturns(result1 *radar.Radar) {
 	}{result1}
 }
 
-func (fake *FakeRadarSchedulerFactory) BuildScheduler(pipelineDB db.PipelineDB) scheduler.BuildScheduler {
+func (fake *FakeRadarSchedulerFactory) BuildScheduler(pipelineDB db.PipelineDB, externalURL string) scheduler.BuildScheduler {
 	fake.buildSchedulerMutex.Lock()
 	fake.buildSchedulerArgsForCall = append(fake.buildSchedulerArgsForCall, struct {
-		pipelineDB db.PipelineDB
-	}{pipelineDB})
+		pipelineDB  db.PipelineDB
+		externalURL string
+	}{pipelineDB, externalURL})
 	fake.buildSchedulerMutex.Unlock()
 	if fake.BuildSchedulerStub != nil {
-		return fake.BuildSchedulerStub(pipelineDB)
+		return fake.BuildSchedulerStub(pipelineDB, externalURL)
 	} else {
 		return fake.buildSchedulerReturns.result1
 	}
@@ -80,10 +84,10 @@ func (fake *FakeRadarSchedulerFactory) BuildSchedulerCallCount() int {
 	return len(fake.buildSchedulerArgsForCall)
 }
 
-func (fake *FakeRadarSchedulerFactory) BuildSchedulerArgsForCall(i int) db.PipelineDB {
+func (fake *FakeRadarSchedulerFactory) BuildSchedulerArgsForCall(i int) (db.PipelineDB, string) {
 	fake.buildSchedulerMutex.RLock()
 	defer fake.buildSchedulerMutex.RUnlock()
-	return fake.buildSchedulerArgsForCall[i].pipelineDB
+	return fake.buildSchedulerArgsForCall[i].pipelineDB, fake.buildSchedulerArgsForCall[i].externalURL
 }
 
 func (fake *FakeRadarSchedulerFactory) BuildSchedulerReturns(result1 scheduler.BuildScheduler) {

--- a/pipelines/radar_scheduler_factory.go
+++ b/pipelines/radar_scheduler_factory.go
@@ -16,8 +16,8 @@ import (
 //go:generate counterfeiter . RadarSchedulerFactory
 
 type RadarSchedulerFactory interface {
-	BuildRadar(pipelineDB db.PipelineDB) *radar.Radar
-	BuildScheduler(pipelineDB db.PipelineDB) scheduler.BuildScheduler
+	BuildRadar(pipelineDB db.PipelineDB, externalURL string) *radar.Radar
+	BuildScheduler(pipelineDB db.PipelineDB, externalURL string) scheduler.BuildScheduler
 }
 
 type radarSchedulerFactory struct {
@@ -41,12 +41,12 @@ func NewRadarSchedulerFactory(
 	}
 }
 
-func (rsf *radarSchedulerFactory) BuildRadar(pipelineDB db.PipelineDB) *radar.Radar {
-	return radar.NewRadar(rsf.tracker, rsf.interval, pipelineDB, clock.NewClock())
+func (rsf *radarSchedulerFactory) BuildRadar(pipelineDB db.PipelineDB, externalURL string) *radar.Radar {
+	return radar.NewRadar(rsf.tracker, rsf.interval, pipelineDB, clock.NewClock(), externalURL)
 }
 
-func (rsf *radarSchedulerFactory) BuildScheduler(pipelineDB db.PipelineDB) scheduler.BuildScheduler {
-	radar := rsf.BuildRadar(pipelineDB)
+func (rsf *radarSchedulerFactory) BuildScheduler(pipelineDB db.PipelineDB, externalURL string) scheduler.BuildScheduler {
+	radar := rsf.BuildRadar(pipelineDB, externalURL)
 	return &scheduler.Scheduler{
 		PipelineDB: pipelineDB,
 		BuildsDB:   rsf.db,

--- a/radar/radar_test.go
+++ b/radar/radar_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Radar", func() {
 		interval = 1 * time.Minute
 
 		fakeRadarDB.GetPipelineNameReturns("some-pipeline")
-		radar = NewRadar(fakeTracker, interval, fakeRadarDB, fakeClock)
+		radar = NewRadar(fakeTracker, interval, fakeRadarDB, fakeClock, "https://www.example.com")
 
 		resourceConfig = atc.ResourceConfig{
 			Name:   "some-resource",
@@ -140,7 +140,12 @@ var _ = Describe("Radar", func() {
 				<-times
 
 				_, metadata, session, typ, tags, customTypes, delegate := fakeTracker.InitArgsForCall(0)
-				Expect(metadata).To(Equal(resource.EmptyMetadata{}))
+				Expect(metadata).To(Equal(resource.TrackerMetadata{
+					ResourceName: "some-resource",
+					PipelineName: "some-pipeline",
+					ExternalURL:  "https://www.example.com",
+				}))
+
 				Expect(session).To(Equal(resource.Session{
 					ID: worker.Identifier{
 						ResourceID:  39,
@@ -588,7 +593,12 @@ var _ = Describe("Radar", func() {
 
 			It("constructs the resource of the correct type", func() {
 				_, metadata, session, typ, tags, _, _ := fakeTracker.InitArgsForCall(0)
-				Expect(metadata).To(Equal(resource.EmptyMetadata{}))
+				Expect(metadata).To(Equal(resource.TrackerMetadata{
+					ResourceName: "some-resource",
+					PipelineName: "some-pipeline",
+					ExternalURL:  "https://www.example.com",
+				}))
+
 				Expect(session).To(Equal(resource.Session{
 					ID: worker.Identifier{
 						ResourceID:  39,

--- a/resource/tracker.go
+++ b/resource/tracker.go
@@ -42,10 +42,6 @@ type Metadata interface {
 	Env() []string
 }
 
-type EmptyMetadata struct{}
-
-func (m EmptyMetadata) Env() []string { return nil }
-
 type tracker struct {
 	workerClient worker.Client
 	db           TrackerDB

--- a/resource/tracker_metadata.go
+++ b/resource/tracker_metadata.go
@@ -1,0 +1,33 @@
+package resource
+
+import "fmt"
+
+type TrackerMetadata struct {
+	ExternalURL  string
+	PipelineName string
+	ResourceName string
+}
+
+type EmptyMetadata struct{}
+
+func (m EmptyMetadata) Env() []string {
+	return nil
+}
+
+func (m TrackerMetadata) Env() []string {
+	var env []string
+
+	if m.ExternalURL != "" {
+		env = append(env, fmt.Sprintf("EXTERNAL_URL=%s", m.ExternalURL))
+	}
+
+	if m.PipelineName != "" {
+		env = append(env, fmt.Sprintf("PIPELINE_NAME=%s", m.PipelineName))
+	}
+
+	if m.ResourceName != "" {
+		env = append(env, fmt.Sprintf("RESOURCE_NAME=%s", m.ResourceName))
+	}
+
+	return env
+}

--- a/resource/tracker_metadata_test.go
+++ b/resource/tracker_metadata_test.go
@@ -1,0 +1,29 @@
+package resource_test
+
+import (
+	. "github.com/concourse/atc/resource"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TrackerMetadata", func() {
+	It("Env", func() {
+		Expect(TrackerMetadata{
+			ExternalURL:  "https://www.example.com",
+			PipelineName: "some-pipeline-name",
+			ResourceName: "some-resource-name",
+		}.Env()).To(Equal([]string{
+			"EXTERNAL_URL=https://www.example.com",
+			"PIPELINE_NAME=some-pipeline-name",
+			"RESOURCE_NAME=some-resource-name",
+		}))
+	})
+
+	It("does not include fields that are not set", func() {
+		Expect(TrackerMetadata{
+			PipelineName: "some-pipeline-name",
+		}.Env()).To(Equal([]string{
+			"PIPELINE_NAME=some-pipeline-name",
+		}))
+	})
+})


### PR DESCRIPTION
This addresses:

https://github.com/concourse/concourse/issues/258

Hoping that passing external URL around like this is ok. Additionally, tried to pick criteria that would identify a check container - it may be wrong.

Where should the documentation for this feature go?

Signed-off-by: Utako Ueda <uueda@pivotal.io>