### PR TITLE
Remove need for auth on cli download

### DIFF
--- a/wrappa/api_auth_wrappa.go
+++ b/wrappa/api_auth_wrappa.go
@@ -68,11 +68,12 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			newHandler = auth.CheckAuthHandler(handler, rejector)
 
 		// unauthenticated
-		case atc.ListAuthMethods, atc.GetInfo:
+		case atc.ListAuthMethods,
+			atc.GetInfo,
+			atc.DownloadCLI:
 
 		// unauthenticated if publicly viewable
 		case atc.BuildEvents,
-			atc.DownloadCLI,
 			atc.GetBuild,
 			atc.GetJobBuild,
 			atc.BuildResources,

--- a/wrappa/api_auth_wrappa_test.go
+++ b/wrappa/api_auth_wrappa_test.go
@@ -185,10 +185,10 @@ var _ = Describe("APIAuthWrappa", func() {
 
 					atc.ListAuthMethods: unauthed(inputHandlers[atc.ListAuthMethods]),
 					atc.GetInfo:         unauthed(inputHandlers[atc.GetInfo]),
+					atc.DownloadCLI:     unauthed(inputHandlers[atc.DownloadCLI]),
 
 					atc.BuildEvents:                   authed(inputHandlers[atc.BuildEvents]),
 					atc.BuildResources:                authed(inputHandlers[atc.BuildResources]),
-					atc.DownloadCLI:                   authed(inputHandlers[atc.DownloadCLI]),
 					atc.GetBuild:                      authed(inputHandlers[atc.GetBuild]),
 					atc.GetBuildPreparation:           authed(inputHandlers[atc.GetBuildPreparation]),
 					atc.GetJob:                        authed(inputHandlers[atc.GetJob]),


### PR DESCRIPTION
Removed the need to be authenticated when downloading the CLI (even when not public). This should pretty much always be a method that you can get to on any concourse server.