### PR TITLE
jobs API endpoint serves SVG badges of latest status

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -144,6 +144,7 @@ func NewHandler(
 		atc.CreateJobBuild: pipelineHandlerFactory.HandlerFor(jobServer.CreateJobBuild),
 		atc.PauseJob:       pipelineHandlerFactory.HandlerFor(jobServer.PauseJob),
 		atc.UnpauseJob:     pipelineHandlerFactory.HandlerFor(jobServer.UnpauseJob),
+		atc.JobBadge:       pipelineHandlerFactory.HandlerFor(jobServer.JobBadge),
 
 		atc.ListPipelines:   http.HandlerFunc(pipelineServer.ListPipelines),
 		atc.GetPipeline:     http.HandlerFunc(pipelineServer.GetPipeline),

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -260,6 +260,291 @@ var _ = Describe("Jobs API", func() {
 		})
 	})
 
+	Describe("GET /api/v1/pipelines/:pipeline_name/jobs/:job_name/badge", func() {
+		var response *http.Response
+
+		JustBeforeEach(func() {
+			var err error
+
+			response, err = client.Get(server.URL + "/api/v1/pipelines/some-pipeline/jobs/some-job/badge")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(pipelineDBFactory.BuildWithTeamNameAndNameCallCount()).To(Equal(1))
+			teamName, pipelineName := pipelineDBFactory.BuildWithTeamNameAndNameArgsForCall(0)
+			Expect(pipelineName).To(Equal("some-pipeline"))
+			Expect(teamName).To(Equal(atc.DefaultTeamName))
+		})
+
+		Context("when getting the job config succeeds", func() {
+			BeforeEach(func() {
+				pipelineDB.GetConfigReturns(atc.Config{
+					Groups: []atc.GroupConfig{
+						{
+							Name: "group-1",
+							Jobs: []string{"some-job"},
+						},
+						{
+							Name: "group-2",
+							Jobs: []string{"some-job"},
+						},
+					},
+
+					Jobs: []atc.JobConfig{
+						{
+							Name: "some-job",
+							Plan: atc.PlanSequence{
+								{
+									Get: "some-input",
+								},
+								{
+									Get:      "some-name",
+									Resource: "some-other-input",
+									Params:   atc.Params{"secret": "params"},
+									Passed:   []string{"a", "b"},
+									Trigger:  true,
+								},
+								{
+									Put: "some-output",
+								},
+								{
+									Put:    "some-other-output",
+									Params: atc.Params{"secret": "params"},
+								},
+							},
+						},
+					},
+				}, 1, true, nil)
+			})
+
+			Context("when the finished build is successful", func() {
+				BeforeEach(func() {
+					pipelineDB.GetJobFinishedAndNextBuildReturns(
+						&db.Build{
+							ID:           1,
+							Name:         "1",
+							JobName:      "some-job",
+							PipelineName: "some-pipeline",
+							Status:       db.StatusSucceeded,
+							StartTime:    time.Unix(1, 0),
+							EndTime:      time.Unix(100, 0),
+						},
+						&db.Build{
+							ID:           3,
+							Name:         "2",
+							JobName:      "some-job",
+							PipelineName: "some-pipeline",
+							Status:       db.StatusStarted,
+						},
+						nil,
+					)
+				})
+
+				It("fetches by job", func() {
+					Expect(pipelineDB.GetJobFinishedAndNextBuildCallCount()).To(Equal(1))
+
+					jobName := pipelineDB.GetJobFinishedAndNextBuildArgsForCall(0)
+					Expect(jobName).To(Equal("some-job"))
+				})
+
+				It("returns 200 OK", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+				})
+
+				It("returns some SVG showing that the job is successful", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(string(body)).To(Equal(`<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><mask id="a"><rect width="88" height="20" rx="3" fill="#fff"/></mask><g mask="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#44cc11" d="M37 0h51v20H37z"/><path fill="url(#b)" d="M0 0h88v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="18.5" y="15" fill="#010101" fill-opacity=".3">build</text><text x="18.5" y="14">build</text><text x="61.5" y="15" fill="#010101" fill-opacity=".3">passing</text><text x="61.5" y="14">passing</text></g></svg>`))
+				})
+			})
+
+			Context("when the finished build is failed", func() {
+				BeforeEach(func() {
+					pipelineDB.GetJobFinishedAndNextBuildReturns(
+						&db.Build{
+							ID:           1,
+							Name:         "1",
+							JobName:      "some-job",
+							PipelineName: "some-pipeline",
+							Status:       db.StatusFailed,
+							StartTime:    time.Unix(1, 0),
+							EndTime:      time.Unix(100, 0),
+						},
+						&db.Build{
+							ID:           3,
+							Name:         "2",
+							JobName:      "some-job",
+							PipelineName: "some-pipeline",
+							Status:       db.StatusStarted,
+						},
+						nil,
+					)
+				})
+
+				It("fetches by job", func() {
+					Expect(pipelineDB.GetJobFinishedAndNextBuildCallCount()).To(Equal(1))
+
+					jobName := pipelineDB.GetJobFinishedAndNextBuildArgsForCall(0)
+					Expect(jobName).To(Equal("some-job"))
+				})
+
+				It("returns 200 OK", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+				})
+
+				It("returns some SVG showing that the job has failed", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(string(body)).To(Equal(`<svg xmlns="http://www.w3.org/2000/svg" width="80" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><mask id="a"><rect width="80" height="20" rx="3" fill="#fff"/></mask><g mask="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#e05d44" d="M37 0h43v20H37z"/><path fill="url(#b)" d="M0 0h80v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="18.5" y="15" fill="#010101" fill-opacity=".3">build</text><text x="18.5" y="14">build</text><text x="57.5" y="15" fill="#010101" fill-opacity=".3">failing</text><text x="57.5" y="14">failing</text></g></svg>`))
+				})
+			})
+
+			Context("when the finished build was aborted", func() {
+				BeforeEach(func() {
+					pipelineDB.GetJobFinishedAndNextBuildReturns(
+						&db.Build{
+							ID:           1,
+							Name:         "1",
+							JobName:      "some-job",
+							PipelineName: "some-pipeline",
+							Status:       db.StatusAborted,
+							StartTime:    time.Unix(1, 0),
+							EndTime:      time.Unix(100, 0),
+						},
+						&db.Build{
+							ID:           3,
+							Name:         "2",
+							JobName:      "some-job",
+							PipelineName: "some-pipeline",
+							Status:       db.StatusStarted,
+						},
+						nil,
+					)
+				})
+
+				It("fetches by job", func() {
+					Expect(pipelineDB.GetJobFinishedAndNextBuildCallCount()).To(Equal(1))
+
+					jobName := pipelineDB.GetJobFinishedAndNextBuildArgsForCall(0)
+					Expect(jobName).To(Equal("some-job"))
+				})
+
+				It("returns 200 OK", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+				})
+
+				It("returns some SVG showing that the job has errored", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(string(body)).To(Equal(`<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><mask id="a"><rect width="90" height="20" rx="3" fill="#fff"/></mask><g mask="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#8f4b2d" d="M37 0h53v20H37z"/><path fill="url(#b)" d="M0 0h90v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="18.5" y="15" fill="#010101" fill-opacity=".3">build</text><text x="18.5" y="14">build</text><text x="62.5" y="15" fill="#010101" fill-opacity=".3">aborted</text><text x="62.5" y="14">aborted</text></g></svg>`))
+				})
+			})
+
+			Context("when the finished build errored", func() {
+				BeforeEach(func() {
+					pipelineDB.GetJobFinishedAndNextBuildReturns(
+						&db.Build{
+							ID:           1,
+							Name:         "1",
+							JobName:      "some-job",
+							PipelineName: "some-pipeline",
+							Status:       db.StatusErrored,
+							StartTime:    time.Unix(1, 0),
+							EndTime:      time.Unix(100, 0),
+						},
+						&db.Build{
+							ID:           3,
+							Name:         "2",
+							JobName:      "some-job",
+							PipelineName: "some-pipeline",
+							Status:       db.StatusStarted,
+						},
+						nil,
+					)
+				})
+
+				It("fetches by job", func() {
+					Expect(pipelineDB.GetJobFinishedAndNextBuildCallCount()).To(Equal(1))
+
+					jobName := pipelineDB.GetJobFinishedAndNextBuildArgsForCall(0)
+					Expect(jobName).To(Equal("some-job"))
+				})
+
+				It("returns 200 OK", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+				})
+
+				It("returns some SVG showing that the job has errored", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(string(body)).To(Equal(`<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><mask id="a"><rect width="88" height="20" rx="3" fill="#fff"/></mask><g mask="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#fe7d37" d="M37 0h51v20H37z"/><path fill="url(#b)" d="M0 0h88v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="18.5" y="15" fill="#010101" fill-opacity=".3">build</text><text x="18.5" y="14">build</text><text x="61.5" y="15" fill="#010101" fill-opacity=".3">errored</text><text x="61.5" y="14">errored</text></g></svg>`))
+				})
+			})
+
+			Context("when there are no running or finished builds", func() {
+				BeforeEach(func() {
+					pipelineDB.GetJobFinishedAndNextBuildReturns(nil, nil, nil)
+				})
+
+				It("returns an unknown badge", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(string(body)).To(Equal(`<svg xmlns="http://www.w3.org/2000/svg" width="98" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><mask id="a"><rect width="98" height="20" rx="3" fill="#fff"/></mask><g mask="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="#9f9f9f" d="M37 0h61v20H37z"/><path fill="url(#b)" d="M0 0h98v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="18.5" y="15" fill="#010101" fill-opacity=".3">build</text><text x="18.5" y="14">build</text><text x="66.5" y="15" fill="#010101" fill-opacity=".3">unknown</text><text x="66.5" y="14">unknown</text></g></svg>`))
+				})
+			})
+
+			Context("when getting the job's builds fails", func() {
+				BeforeEach(func() {
+					pipelineDB.GetJobFinishedAndNextBuildReturns(nil, nil, errors.New("oh no!"))
+				})
+
+				It("returns 500", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+				})
+			})
+
+			Context("when the job is not present in the config", func() {
+				BeforeEach(func() {
+					pipelineDB.GetConfigReturns(atc.Config{
+						Jobs: []atc.JobConfig{
+							{Name: "other-job"},
+						},
+					}, 1, true, nil)
+				})
+
+				It("returns 404", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+				})
+			})
+		})
+
+		Context("when getting the job config fails", func() {
+			Context("when the pipeline is no longer configured", func() {
+				BeforeEach(func() {
+					pipelineDB.GetConfigReturns(atc.Config{}, 0, false, nil)
+				})
+
+				It("returns 404", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+				})
+			})
+
+			Context("with an unknown error", func() {
+				BeforeEach(func() {
+					pipelineDB.GetConfigReturns(atc.Config{}, 0, false, errors.New("oh no!"))
+				})
+
+				It("returns 500", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+				})
+			})
+		})
+	})
+
 	Describe("GET /api/v1/pipelines/:pipeline_name/jobs", func() {
 		var response *http.Response
 		var jobs []atc.JobConfig

--- a/api/jobserver/badge.go
+++ b/api/jobserver/badge.go
@@ -1,0 +1,89 @@
+package jobserver
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/concourse/atc/db"
+)
+
+var (
+	badgePassing = badge{width: 88, fillColor: `#44cc11`, status: `passing`}
+	badgeFailing = badge{width: 80, fillColor: `#e05d44`, status: `failing`}
+	badgeUnknown = badge{width: 98, fillColor: `#9f9f9f`, status: `unknown`}
+	badgeAborted = badge{width: 90, fillColor: `#8f4b2d`, status: `aborted`}
+	badgeErrored = badge{width: 88, fillColor: `#fe7d37`, status: `errored`}
+)
+
+type badge struct {
+	width     int
+	fillColor string
+	status    string
+}
+
+func (b *badge) statusWidth() int {
+	return b.width - 37
+}
+
+func (b *badge) statusTextWidth() float64 {
+	return float64(b.width)/2 + 17.5
+}
+
+func (b *badge) getSvg() string {
+	const svgTemplate = `<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="20"><linearGradient id="b" x2="0" y2="100%%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><mask id="a"><rect width="%d" height="20" rx="3" fill="#fff"/></mask><g mask="url(#a)"><path fill="#555" d="M0 0h37v20H0z"/><path fill="%s" d="M37 0h%dv20H37z"/><path fill="url(#b)" d="M0 0h%dv20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="18.5" y="15" fill="#010101" fill-opacity=".3">build</text><text x="18.5" y="14">build</text><text x="%.1f" y="15" fill="#010101" fill-opacity=".3">%s</text><text x="%.1f" y="14">%s</text></g></svg>`
+	return fmt.Sprintf(svgTemplate, b.width, b.width, b.fillColor, b.statusWidth(), b.width, b.statusTextWidth(), b.status, b.statusTextWidth(), b.status)
+}
+
+func statusSvg(finished *db.Build) string {
+	switch {
+	case finished == nil:
+		return badgeUnknown.getSvg()
+	case finished.Status == db.StatusSucceeded:
+		return badgePassing.getSvg()
+	case finished.Status == db.StatusFailed:
+		return badgeFailing.getSvg()
+	case finished.Status == db.StatusAborted:
+		return badgeAborted.getSvg()
+	case finished.Status == db.StatusErrored:
+		return badgeErrored.getSvg()
+	}
+	return badgeUnknown.getSvg()
+}
+
+func (s *Server) JobBadge(pipelineDB db.PipelineDB) http.Handler {
+	logger := s.logger.Session("job-badge")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jobName := r.FormValue(":job_name")
+
+		config, _, found, err := pipelineDB.GetConfig()
+		if err != nil {
+			logger.Error("could-not-get-pipeline-config", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if !found {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		_, found = config.Jobs.Lookup(jobName)
+		if !found {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		finished, _, err := pipelineDB.GetJobFinishedAndNextBuild(jobName)
+		if err != nil {
+			logger.Error("could-not-get-job-finished-and-next-build", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-type", "image/svg+xml")
+
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, statusSvg(finished))
+	})
+}

--- a/routes.go
+++ b/routes.go
@@ -24,6 +24,7 @@ const (
 	PauseJob       = "PauseJob"
 	UnpauseJob     = "UnpauseJob"
 	GetVersionsDB  = "GetVersionsDB"
+	JobBadge       = "JobBadge"
 
 	ListResources   = "ListResources"
 	GetResource     = "GetResource"
@@ -91,6 +92,7 @@ var Routes = rata.Routes([]rata.Route{
 	{Path: "/api/v1/pipelines/:pipeline_name/jobs/:job_name/builds/:build_name", Method: "GET", Name: GetJobBuild},
 	{Path: "/api/v1/pipelines/:pipeline_name/jobs/:job_name/pause", Method: "PUT", Name: PauseJob},
 	{Path: "/api/v1/pipelines/:pipeline_name/jobs/:job_name/unpause", Method: "PUT", Name: UnpauseJob},
+	{Path: "/api/v1/pipelines/:pipeline_name/jobs/:job_name/badge", Method: "GET", Name: JobBadge},
 
 	{Path: "/api/v1/pipelines", Method: "GET", Name: ListPipelines},
 	{Path: "/api/v1/pipelines/:pipeline_name", Method: "GET", Name: GetPipeline},

--- a/wrappa/api_auth_wrappa.go
+++ b/wrappa/api_auth_wrappa.go
@@ -77,6 +77,7 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.GetJobBuild,
 			atc.BuildResources,
 			atc.GetJob,
+			atc.JobBadge,
 			atc.GetLogLevel,
 			atc.GetResource,
 			atc.ListResourceVersions,


### PR DESCRIPTION
@xoebus did the heavy lifting.

- typical URI:
  [https://ci.blabbertabber.com/api/v1/pipelines/main/jobs/always-succeeds/badge](https://ci.blabbertabber.com/api/v1/pipelines/main/jobs/always-succeeds/badge)

| Build Status      | Shield                                                                 | Implemented |
--------------------|------------------------------------------------------------------------|----------------|
| `nil` (build never run)             | ![unknown](https://img.shields.io/badge/build-unknown-lightgrey.svg)   | yes |
| `StatusAborted`   | ![unknown](https://img.shields.io/badge/build-aborted-8f4b2d.svg)   | yes |
| `StatusSucceeded` | ![passing](https://img.shields.io/badge/build-passing-brightgreen.svg) | yes |
| `StatusFailed`    | ![failing](https://img.shields.io/badge/build-failing-red.svg)         | yes |
| `StatusErrored`   | ![unknown](https://img.shields.io/badge/build-errored-orange.svg)   | yes |

- Similar to the badges served by [Travis CI](https://travis-ci.com/)
- SVG created courtesy [shields.io](http://shields.io/)
- Badge style: flat

Here's a deployment of a Concourse dev release with the badges: [https://ci.blabbertabber.com](https://ci.blabbertabber.com):

<img width="262" alt="badge-pipeline" src="https://cloud.githubusercontent.com/assets/1020675/14932876/612605a4-0e33-11e6-96f0-393650871e38.png">

And here are the badges (***pulled from the live site!***):

- ![passing](https://ci.blabbertabber.com/api/v1/pipelines/main/jobs/always-succeeds/badge)
- ![failing](https://ci.blabbertabber.com/api/v1/pipelines/main/jobs/always-fails/badge)
- ![aborted](https://ci.blabbertabber.com/api/v1/pipelines/main/jobs/aborted/badge)
- ![errored](https://ci.blabbertabber.com/api/v1/pipelines/main/jobs/always-errors/badge)
- ![unknown](https://ci.blabbertabber.com/api/v1/pipelines/main/jobs/never-run/badge)

[fixes #72388008]

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>