### PR TITLE
add a disable-intercept option

### DIFF
--- a/api/containerserver/hijack.go
+++ b/api/containerserver/hijack.go
@@ -17,6 +17,11 @@ var upgrader = websocket.Upgrader{
 }
 
 func (s *Server) HijackContainer(w http.ResponseWriter, r *http.Request) {
+	if s.disableHijack {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
 	handle := r.FormValue(":id")
 
 	hLog := s.logger.Session("hijack", lager.Data{

--- a/api/containerserver/server.go
+++ b/api/containerserver/server.go
@@ -12,6 +12,8 @@ type Server struct {
 	workerClient worker.Client
 
 	db ContainerDB
+
+	disableHijack bool
 }
 
 //go:generate counterfeiter . ContainerDB
@@ -25,10 +27,12 @@ func NewServer(
 	logger lager.Logger,
 	workerClient worker.Client,
 	db ContainerDB,
+	disableHijack bool,
 ) *Server {
 	return &Server{
-		logger:       logger,
-		workerClient: workerClient,
-		db:           db,
+		logger:        logger,
+		workerClient:  workerClient,
+		db:            db,
+		disableHijack: disableHijack,
 	}
 }

--- a/api/handler.go
+++ b/api/handler.go
@@ -66,6 +66,7 @@ func NewHandler(
 	scannerFactory resourceserver.ScannerFactory,
 
 	sink *lager.ReconfigurableSink,
+	disableHijack bool,
 
 	cliDownloadsDir string,
 	version string,
@@ -112,7 +113,7 @@ func NewHandler(
 
 	cliServer := cliserver.NewServer(logger, absCLIDownloadsDir)
 
-	containerServer := containerserver.NewServer(logger, workerClient, containerDB)
+	containerServer := containerserver.NewServer(logger, workerClient, containerDB, disableHijack)
 
 	volumesServer := volumeserver.NewServer(logger, volumesDB)
 

--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -72,6 +72,8 @@ type ATCCommand struct {
 
 	PubliclyViewable bool `short:"p" long:"publicly-viewable" default:"false" description:"If true, anonymous users can view pipelines and public jobs."`
 
+	DisableHijack bool `long:"disable-intercept" default:"false" description:"If true, users can not intercept to containers."`
+
 	SessionSigningKey FileFlag `long:"session-signing-key" description:"File containing an RSA private key, used to sign session tokens."`
 
 	ResourceCheckingInterval     time.Duration `long:"resource-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources."`
@@ -801,6 +803,7 @@ func (cmd *ATCCommand) constructAPIHandler(
 		radarScannerFactory,
 
 		reconfigurableSink,
+		cmd.DisableHijack,
 
 		cmd.CLIArtifactsDir.Path(),
 		Version,


### PR DESCRIPTION
## what
I created a new option `--disable-intercept`.
If true, `fly hijack ( or intercept)` commands will be denied.

## why
I'm considering to collaborate the concourse with our GitHub Enterprise.
I try to use a `concourse` bot user to pull/push from all pipelines (with customizing git-resource).
With this, every developers needs not to expose their private keys.
Customizing git-resource will include `concourse` private key, so I use this disable-intercept option in order to hide this private key.

Let me know if anything looks bad. 