### PR TITLE
Update Garden fakes to new schema

### DIFF
--- a/api/containers_test.go
+++ b/api/containers_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/cloudfoundry-incubator/garden"
-	gfakes "github.com/cloudfoundry-incubator/garden/fakes"
+	gfakes "github.com/cloudfoundry-incubator/garden/gardenfakes"
 	"github.com/gorilla/websocket"
 
 	"github.com/concourse/atc"

--- a/exec/task_step_test.go
+++ b/exec/task_step_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/cloudfoundry-incubator/garden"
-	gfakes "github.com/cloudfoundry-incubator/garden/fakes"
+	gfakes "github.com/cloudfoundry-incubator/garden/gardenfakes"
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/db"
 	. "github.com/concourse/atc/exec"

--- a/resource/resource_check_test.go
+++ b/resource/resource_check_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 
 	"github.com/cloudfoundry-incubator/garden"
-	gfakes "github.com/cloudfoundry-incubator/garden/fakes"
+	gfakes "github.com/cloudfoundry-incubator/garden/gardenfakes"
 	"github.com/concourse/atc"
 
 	. "github.com/onsi/ginkgo"

--- a/resource/resource_in_test.go
+++ b/resource/resource_in_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onsi/gomega/gbytes"
 
 	"github.com/cloudfoundry-incubator/garden"
-	gfakes "github.com/cloudfoundry-incubator/garden/fakes"
+	gfakes "github.com/cloudfoundry-incubator/garden/gardenfakes"
 	"github.com/tedsuo/ifrit"
 
 	"github.com/concourse/atc"

--- a/resource/resource_out_test.go
+++ b/resource/resource_out_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/cloudfoundry-incubator/garden"
-	gfakes "github.com/cloudfoundry-incubator/garden/fakes"
+	gfakes "github.com/cloudfoundry-incubator/garden/gardenfakes"
 	"github.com/tedsuo/ifrit"
 
 	. "github.com/onsi/ginkgo"

--- a/worker/db_provider_test.go
+++ b/worker/db_provider_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/cloudfoundry-incubator/garden"
-	gfakes "github.com/cloudfoundry-incubator/garden/fakes"
+	gfakes "github.com/cloudfoundry-incubator/garden/gardenfakes"
 	"github.com/cloudfoundry-incubator/garden/server"
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/db"

--- a/worker/retryable_garden_connection_test.go
+++ b/worker/retryable_garden_connection_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cloudfoundry-incubator/garden"
 	fconn "github.com/cloudfoundry-incubator/garden/client/connection/fakes"
-	gfakes "github.com/cloudfoundry-incubator/garden/fakes"
+	gfakes "github.com/cloudfoundry-incubator/garden/gardenfakes"
 	"github.com/concourse/atc/worker"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/cloudfoundry-incubator/garden"
-	gfakes "github.com/cloudfoundry-incubator/garden/fakes"
+	gfakes "github.com/cloudfoundry-incubator/garden/gardenfakes"
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/db"
 	. "github.com/concourse/atc/worker"


### PR DESCRIPTION
Garden switched to a new fakes schema, fakes is renamed to gardenfakes since this commit:

https://github.com/cloudfoundry-incubator/garden/commit/c569d61e0ad1badd67d17762d0b33ea6942e090f