### PR TITLE
Update CONTRIBUTING.md with note about fly CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,3 +81,23 @@ go run cmd/atc/*.go -d
 ```
 
 Concourse should be live at http://localhost:8080
+
+
+## Building the fly command line tool
+
+If you try to use a realse version of `fly` you will get errors like this:
+
+```
+fly -t local ps 
+targeting http://localhost:8080
+
+error: strconv.ParseInt: parsing "0-dev": invalid syntax
+```
+
+To work around that you need to build a local copy and use that instead
+
+```
+cd ${concourse}/src/github.com/concourse/fly
+go build -o fly main.go
+alias fly=${concourse}/src/github.com/concourse/fly/fly
+```


### PR DESCRIPTION
The `fly` CLI can fail with the build version. This just adds some additional notes about how to build it.
