### PR TITLE
Added generic oauth login option.

### DIFF
--- a/acceptance/atc_command_test.go
+++ b/acceptance/atc_command_test.go
@@ -32,6 +32,8 @@ const UAA_AUTH = "cf"
 const UAA_AUTH_NO_CLIENT_SECRET = "cf-no-secret"
 const UAA_AUTH_NO_TOKEN_URL = "cf-no-token-url"
 const UAA_AUTH_NO_SPACE = "cf-no-space"
+const GENERIC_OAUTH_AUTH = "generic-oauth"
+const GENERIC_OAUTH_AUTH_PARAMS = "generic-oauth-params"
 const NOT_CONFIGURED_AUTH = "not-configured"
 const DEVELOPMENT_MODE = "dev"
 const NO_AUTH = DEVELOPMENT_MODE
@@ -217,6 +219,24 @@ func (a *ATCCommand) getATCCommand() *exec.Cmd {
 				"--uaa-auth-cf-space", "myspace",
 				"--uaa-auth-auth-url", "https://uaa.example.com/oauth/authorize",
 				"--uaa-auth-cf-url", "https://cf.example.com/api",
+			)
+		case GENERIC_OAUTH_AUTH:
+			params = append(params,
+				"--generic-oauth-display-name", "Example",
+				"--generic-oauth-client-id", "admin",
+				"--generic-oauth-client-secret", "password",
+				"--generic-oauth-auth-url", "https://goa.example.com/oauth/authorize",
+				"--generic-oauth-token-url", "https://goa.example.com/oauth/token",
+			)
+		case GENERIC_OAUTH_AUTH_PARAMS:
+			params = append(params,
+				"--generic-oauth-display-name", "Example",
+				"--generic-oauth-client-id", "admin",
+				"--generic-oauth-client-secret", "password",
+				"--generic-oauth-auth-url", "https://goa.example.com/oauth/authorize",
+				"--generic-oauth-auth-url-param", "param1:value1",
+				"--generic-oauth-auth-url-param", "param2:value2",
+				"--generic-oauth-token-url", "https://goa.example.com/oauth/token",
 			)
 		case DEVELOPMENT_MODE:
 			params = append(params, "--development-mode")

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -166,6 +166,11 @@ var _ = Describe("Auth API", func() {
 							ClientID:     "client-id",
 							ClientSecret: "client-secret",
 						},
+						GenericOAuth: &db.GenericOAuth{
+							ClientID:     "client-id",
+							ClientSecret: "client-secret",
+							DisplayName:  "custom secure auth",
+						},
 					},
 				}
 
@@ -209,6 +214,11 @@ var _ = Describe("Auth API", func() {
 						"type": "oauth",
 						"display_name": "UAA",
 						"auth_url": "https://oauth.example.com/auth/uaa?team_name=some-team"
+					},
+					{
+						"type": "oauth",
+						"display_name": "custom secure auth",
+						"auth_url": "https://oauth.example.com/auth/oauth?team_name=some-team"
 					},
 					{
 						"type": "basic",

--- a/api/authserver/list_auth_methods.go
+++ b/api/authserver/list_auth_methods.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/auth"
+	"github.com/concourse/atc/auth/genericoauth"
 	"github.com/concourse/atc/auth/github"
 	"github.com/concourse/atc/auth/uaa"
 	"github.com/concourse/atc/db"
@@ -94,6 +95,23 @@ func (s *Server) authMethods(team db.SavedTeam) ([]atc.AuthMethod, error) {
 		methods = append(methods, atc.AuthMethod{
 			Type:        atc.AuthTypeOAuth,
 			DisplayName: uaa.DisplayName,
+			AuthURL:     s.oAuthBaseURL + path,
+		})
+	}
+
+	if team.GenericOAuth != nil {
+		path, err := auth.OAuthRoutes.CreatePathForRoute(
+			auth.OAuthBegin,
+			rata.Params{"provider": genericoauth.ProviderName},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		path = path + fmt.Sprintf("?team_name=%s", team.Name)
+		methods = append(methods, atc.AuthMethod{
+			Type:        atc.AuthTypeOAuth,
+			DisplayName: team.GenericOAuth.DisplayName,
 			AuthURL:     s.oAuthBaseURL + path,
 		})
 	}

--- a/api/teams_test.go
+++ b/api/teams_test.go
@@ -737,9 +737,19 @@ var _ = Describe("Teams API", func() {
 							team.BasicAuth = &basicAuth
 						})
 
-						It("updates the basic auth for that team", func() {
+						It("creates a team with basic auth credentials", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusCreated))
 							Expect(teamServerDB.CreateTeamCallCount()).To(Equal(1))
+
+							createdTeam := teamServerDB.CreateTeamArgsForCall(0)
+							Expect(createdTeam).To(Not(BeNil()))
+
+							Expect(createdTeam.BasicAuth).To(Not(BeNil()))
+							Expect(createdTeam.BasicAuth.BasicAuthUsername).To(Equal("Dean Venture"))
+							Expect(createdTeam.BasicAuth.BasicAuthPassword).To(Equal("Giant Boy Detective"))
+							Expect(createdTeam.GitHubAuth).To(BeNil())
+							Expect(createdTeam.UAAAuth).To(BeNil())
+							Expect(createdTeam.GenericOAuth).To(BeNil())
 						})
 					})
 
@@ -748,9 +758,20 @@ var _ = Describe("Teams API", func() {
 							team.GitHubAuth = &gitHubAuth
 						})
 
-						It("updates the GitHub auth for that team", func() {
+						It("creates a team with GitHub auth credentials", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusCreated))
 							Expect(teamServerDB.CreateTeamCallCount()).To(Equal(1))
+
+							createdTeam := teamServerDB.CreateTeamArgsForCall(0)
+							Expect(createdTeam).To(Not(BeNil()))
+
+							Expect(createdTeam.BasicAuth).To(BeNil())
+							Expect(createdTeam.GitHubAuth).To(Not(BeNil()))
+							Expect(createdTeam.GitHubAuth.ClientID).To(Equal("Dean Venture"))
+							Expect(createdTeam.GitHubAuth.ClientSecret).To(Equal("Giant Boy Detective"))
+							Expect(createdTeam.GitHubAuth.Users).To(Equal([]string{"Dean Venture"}))
+							Expect(createdTeam.UAAAuth).To(BeNil())
+							Expect(createdTeam.GenericOAuth).To(BeNil())
 						})
 					})
 
@@ -759,9 +780,21 @@ var _ = Describe("Teams API", func() {
 							team.GenericOAuth = &genericOAuth
 						})
 
-						It("updates the Generic OAuth auth for that team", func() {
+						It("creates a team with Generic OAuth credentials", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusCreated))
 							Expect(teamServerDB.CreateTeamCallCount()).To(Equal(1))
+
+							createdTeam := teamServerDB.CreateTeamArgsForCall(0)
+							Expect(createdTeam).To(Not(BeNil()))
+
+							Expect(createdTeam.BasicAuth).To(BeNil())
+							Expect(createdTeam.GitHubAuth).To(BeNil())
+							Expect(createdTeam.UAAAuth).To(BeNil())
+							Expect(createdTeam.GenericOAuth.DisplayName).To(Equal("Cyborgs"))
+							Expect(createdTeam.GenericOAuth.ClientID).To(Equal("Dean Venture"))
+							Expect(createdTeam.GenericOAuth.ClientSecret).To(Equal("Giant Boy Detective"))
+							Expect(createdTeam.GenericOAuth.AuthURL).To(Equal("auth.url"))
+							Expect(createdTeam.GenericOAuth.TokenURL).To(Equal("token.url"))
 						})
 					})
 				})

--- a/api/teams_test.go
+++ b/api/teams_test.go
@@ -797,6 +797,17 @@ var _ = Describe("Teams API", func() {
 							Expect(createdTeam.GenericOAuth.TokenURL).To(Equal("token.url"))
 						})
 					})
+
+					Context("when passed Generic OAuth credentials", func() {
+						BeforeEach(func() {
+							team.GenericOAuth = &genericOAuth
+						})
+
+						It("updates the Generic OAuth auth for that team", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusCreated))
+							Expect(teamServerDB.CreateTeamCallCount()).To(Equal(1))
+						})
+					})
 				})
 			})
 		})

--- a/api/teams_test.go
+++ b/api/teams_test.go
@@ -448,6 +448,7 @@ var _ = Describe("Teams API", func() {
 					var basicAuth *atc.BasicAuth
 					var gitHubAuth *atc.GitHubAuth
 					var uaaAuth *atc.UAAAuth
+					var genericOAuth *atc.GenericOAuth
 
 					BeforeEach(func() {
 						basicAuth = &atc.BasicAuth{
@@ -468,6 +469,15 @@ var _ = Describe("Teams API", func() {
 							AuthURL:      "http://uaa.auth.url",
 							TokenURL:     "http://uaa.token.url",
 							CFURL:        "http://api.cf.url",
+						}
+
+						genericOAuth = &atc.GenericOAuth{
+							ClientID:      "Dean Venture",
+							ClientSecret:  "Giant Boy Detective",
+							AuthURL:       "https://goa.auth.url",
+							AuthURLParams: map[string]string{},
+							TokenURL:      "https://goa.token.url",
+							DisplayName:   "CSI",
 						}
 					})
 
@@ -543,6 +553,31 @@ var _ = Describe("Teams API", func() {
 							Expect(teamDB.UpdateUAAAuthCallCount()).To(Equal(1))
 						})
 					})
+
+					Context("when passed generic OAuth auth credentials", func() {
+						BeforeEach(func() {
+							teamDB.UpdateGenericOAuthStub = func(genericOAuth *db.GenericOAuth) (db.SavedTeam, error) {
+								team.Name = teamName
+								Expect(genericOAuth.ClientID).To(Equal(team.GenericOAuth.ClientID))
+								Expect(genericOAuth.ClientSecret).To(Equal(team.GenericOAuth.ClientSecret))
+								Expect(genericOAuth.AuthURL).To(Equal(team.GenericOAuth.AuthURL))
+								Expect(genericOAuth.TokenURL).To(Equal(team.GenericOAuth.TokenURL))
+								Expect(genericOAuth.AuthURLParams).To(Equal(team.GenericOAuth.AuthURLParams))
+								Expect(genericOAuth.DisplayName).To(Equal(team.GenericOAuth.DisplayName))
+
+								savedTeam.GenericOAuth = genericOAuth
+								return savedTeam, nil
+							}
+
+							team.GenericOAuth = genericOAuth
+						})
+
+						It("updates the GitHub auth for that team", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusOK))
+							Expect(teamDB.UpdateUAAAuthCallCount()).To(Equal(1))
+						})
+					})
+
 				})
 			})
 

--- a/api/teams_test.go
+++ b/api/teams_test.go
@@ -803,9 +803,21 @@ var _ = Describe("Teams API", func() {
 							team.GenericOAuth = &genericOAuth
 						})
 
-						It("updates the Generic OAuth auth for that team", func() {
+						It("creates a team with Generic OAuth credentials", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusCreated))
 							Expect(teamServerDB.CreateTeamCallCount()).To(Equal(1))
+
+							createdTeam := teamServerDB.CreateTeamArgsForCall(0)
+							Expect(createdTeam).To(Not(BeNil()))
+
+							Expect(createdTeam.BasicAuth).To(BeNil())
+							Expect(createdTeam.GitHubAuth).To(BeNil())
+							Expect(createdTeam.UAAAuth).To(BeNil())
+							Expect(createdTeam.GenericOAuth.DisplayName).To(Equal("Cyborgs"))
+							Expect(createdTeam.GenericOAuth.ClientID).To(Equal("Dean Venture"))
+							Expect(createdTeam.GenericOAuth.ClientSecret).To(Equal("Giant Boy Detective"))
+							Expect(createdTeam.GenericOAuth.AuthURL).To(Equal("auth.url"))
+							Expect(createdTeam.GenericOAuth.TokenURL).To(Equal("token.url"))
 						})
 					})
 				})

--- a/api/teamserver/set.go
+++ b/api/teamserver/set.go
@@ -97,6 +97,11 @@ func (s *Server) updateCredentials(team db.Team, teamDB db.TeamDB) error {
 		return err
 	}
 
+	_, err = teamDB.UpdateGenericOAuth(team.GenericOAuth)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -144,6 +149,20 @@ func (s *Server) validate(team db.Team) error {
 
 		if team.UAAAuth.AuthURL == "" || team.UAAAuth.TokenURL == "" || team.UAAAuth.CFURL == "" {
 			return errors.New("CF auth requires AuthURL, TokenURL and APIURL")
+		}
+	}
+
+	if team.GenericOAuth != nil {
+		if team.GenericOAuth.ClientID == "" || team.GenericOAuth.ClientSecret == "" {
+			return errors.New("Generic OAuth requires ClientID and ClientSecret")
+		}
+
+		if team.GenericOAuth.AuthURL == "" || team.GenericOAuth.TokenURL == "" {
+			return errors.New("Generic OAuth requires an AuthURL and TokenURL")
+		}
+
+		if team.GenericOAuth.DisplayName == "" {
+			return errors.New("Generic OAuth requires a Display Name")
 		}
 	}
 

--- a/auth/genericoauth/goa_suite_test.go
+++ b/auth/genericoauth/goa_suite_test.go
@@ -1,0 +1,13 @@
+package genericoauth_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestGoa(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Generic OAuth Suite")
+}

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -82,18 +82,10 @@ func (provider Provider) DisplayName() string {
 	return provider.Config.DisplayName
 }
 
-<<<<<<< HEAD
 func (Provider) PreTokenClient() (*http.Client, error) {
-=======
-func (Provider) PreTokenClient() *http.Client {
->>>>>>> Added generic oauth login option.
 	return &http.Client{
 		Transport: &http.Transport{
 			DisableKeepAlives: true,
 		},
-<<<<<<< HEAD
 	}, nil
-=======
-	}
->>>>>>> Added generic oauth login option.
 }

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -1,0 +1,91 @@
+package genericoauth
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/atc/auth/verifier"
+	"github.com/concourse/atc/db"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+)
+
+const ProviderName = "oauth"
+
+type NoopVerifier struct{}
+
+func (v NoopVerifier) Verify(logger lager.Logger, client *http.Client) (bool, error) {
+	return true, nil
+}
+
+func NewProvider(
+	genericOAuth *db.GenericOAuth,
+	redirectURL string,
+) Provider {
+	endpoint := oauth2.Endpoint{}
+	if genericOAuth.AuthURL != "" && genericOAuth.TokenURL != "" {
+		endpoint.AuthURL = genericOAuth.AuthURL
+		endpoint.TokenURL = genericOAuth.TokenURL
+	}
+
+	return Provider{
+		Verifier: NoopVerifier{},
+		Config: ConfigOverride{
+			Config: oauth2.Config{
+				ClientID:     genericOAuth.ClientID,
+				ClientSecret: genericOAuth.ClientSecret,
+				Endpoint:     endpoint,
+				RedirectURL:  redirectURL,
+			},
+			DisplayName:   genericOAuth.DisplayName,
+			AuthURLParams: genericOAuth.AuthURLParams,
+		},
+	}
+}
+
+type Provider struct {
+	verifier.Verifier
+	Config ConfigOverride
+}
+
+type ConfigOverride struct {
+	oauth2.Config
+	DisplayName   string
+	AuthURLParams map[string]string
+}
+
+// oauth2.Config implements the required Provider methods:
+// AuthCodeURL(string, ...oauth2.AuthCodeOption) string
+// Exchange(context.Context, string) (*oauth2.Token, error)
+// Client(context.Context, *oauth2.Token) *http.Client
+
+// override the default Provider method implementation from
+// oauth2.Config in order to pass the extra configured Auth
+// URL parameters
+
+func (provider Provider) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+	for key, value := range provider.Config.AuthURLParams {
+		opts = append(opts, oauth2.SetAuthURLParam(key, value))
+	}
+	return provider.Config.AuthCodeURL(state, opts...)
+}
+
+func (provider Provider) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
+	return provider.Config.Exchange(ctx, code)
+}
+
+func (provider Provider) Client(ctx context.Context, t *oauth2.Token) *http.Client {
+	return provider.Config.Client(ctx, t)
+}
+
+func (provider Provider) DisplayName() string {
+	return provider.Config.DisplayName
+}
+
+func (Provider) PreTokenClient() (*http.Client, error) {
+	return &http.Client{
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+		},
+	}, nil
+}

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -37,7 +37,6 @@ func NewProvider(
 				Endpoint:     endpoint,
 				RedirectURL:  redirectURL,
 			},
-			DisplayName:   genericOAuth.DisplayName,
 			AuthURLParams: genericOAuth.AuthURLParams,
 		},
 	}
@@ -50,7 +49,6 @@ type Provider struct {
 
 type ConfigOverride struct {
 	oauth2.Config
-	DisplayName   string
 	AuthURLParams map[string]string
 }
 
@@ -76,10 +74,6 @@ func (provider Provider) Exchange(ctx context.Context, code string) (*oauth2.Tok
 
 func (provider Provider) Client(ctx context.Context, t *oauth2.Token) *http.Client {
 	return provider.Config.Client(ctx, t)
-}
-
-func (provider Provider) DisplayName() string {
-	return provider.Config.DisplayName
 }
 
 func (Provider) PreTokenClient() (*http.Client, error) {

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -82,10 +82,18 @@ func (provider Provider) DisplayName() string {
 	return provider.Config.DisplayName
 }
 
+<<<<<<< HEAD
 func (Provider) PreTokenClient() (*http.Client, error) {
+=======
+func (Provider) PreTokenClient() *http.Client {
+>>>>>>> Added generic oauth login option.
 	return &http.Client{
 		Transport: &http.Transport{
 			DisableKeepAlives: true,
 		},
+<<<<<<< HEAD
 	}, nil
+=======
+	}
+>>>>>>> Added generic oauth login option.
 }

--- a/auth/genericoauth/provider_test.go
+++ b/auth/genericoauth/provider_test.go
@@ -34,10 +34,11 @@ var _ = Describe("Generic OAuth Provider", func() {
 	})
 
 	It("constructs HTTP client with disable keep alive context", func() {
-		httpClient := goaProvider.PreTokenClient()
+		httpClient, err := goaProvider.PreTokenClient()
 		Expect(httpClient).NotTo(BeNil())
 		Expect(httpClient.Transport).NotTo(BeNil())
 		Expect(httpClient.Transport.(*http.Transport).DisableKeepAlives).To(BeTrue())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("constructs the Auth URL with the redirect uri", func() {
@@ -56,19 +57,6 @@ var _ = Describe("Generic OAuth Provider", func() {
 		verifyResult, err := goaProvider.Verify(lagertest.NewTestLogger("test"), nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(verifyResult).To(Equal(true))
-	})
-
-	Context("DisplayName is configured", func() {
-		BeforeEach(func() {
-			dbGenericOAuth = &db.GenericOAuth{DisplayName: "Cyborgs"}
-		})
-
-		It("uses the configured DisplayName instead of the provider name", func() {
-			displayName := goaProvider.DisplayName()
-
-			Expect(displayName).To(Equal("Cyborgs"))
-			Expect(genericoauth.ProviderName).ToNot(Equal("Cyborgs"))
-		})
 	})
 
 	Context("Auth URL params are configured", func() {

--- a/auth/genericoauth/provider_test.go
+++ b/auth/genericoauth/provider_test.go
@@ -1,0 +1,104 @@
+package genericoauth_test
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/lager/lagertest"
+
+	"golang.org/x/oauth2"
+
+	"github.com/concourse/atc/auth/genericoauth"
+	"github.com/concourse/atc/auth/provider"
+	"github.com/concourse/atc/db"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Generic OAuth Provider", func() {
+	var (
+		dbGenericOAuth *db.GenericOAuth
+		redirectURI    string
+		goaProvider    provider.Provider
+		state          string
+	)
+
+	JustBeforeEach(func() {
+		goaProvider = genericoauth.NewProvider(dbGenericOAuth, redirectURI)
+	})
+
+	BeforeEach(func() {
+		dbGenericOAuth = &db.GenericOAuth{}
+		redirectURI = "redirect-uri"
+		state = "some-random-guid"
+	})
+
+	It("constructs HTTP client with disable keep alive context", func() {
+		httpClient := goaProvider.PreTokenClient()
+		Expect(httpClient).NotTo(BeNil())
+		Expect(httpClient.Transport).NotTo(BeNil())
+		Expect(httpClient.Transport.(*http.Transport).DisableKeepAlives).To(BeTrue())
+	})
+
+	It("constructs the Auth URL with the redirect uri", func() {
+		authURI := goaProvider.AuthCodeURL(state, []oauth2.AuthCodeOption{}...)
+
+		Expect(authURI).To(ContainSubstring("redirect_uri=redirect-uri"))
+	})
+
+	It("constructs the Auth URL with the state param", func() {
+		authURI := goaProvider.AuthCodeURL(state, []oauth2.AuthCodeOption{}...)
+
+		Expect(authURI).To(ContainSubstring("state=some-random-guid"))
+	})
+
+	It("doesn't do any user authorization", func() {
+		verifyResult, err := goaProvider.Verify(lagertest.NewTestLogger("test"), nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(verifyResult).To(Equal(true))
+	})
+
+	Context("DisplayName is configured", func() {
+		BeforeEach(func() {
+			dbGenericOAuth = &db.GenericOAuth{DisplayName: "Cyborgs"}
+		})
+
+		It("uses the configured DisplayName instead of the provider name", func() {
+			displayName := goaProvider.DisplayName()
+
+			Expect(displayName).To(Equal("Cyborgs"))
+			Expect(genericoauth.ProviderName).ToNot(Equal("Cyborgs"))
+		})
+	})
+
+	Context("Auth URL params are configured", func() {
+		BeforeEach(func() {
+			redirectURI = "redirect-uri"
+			dbGenericOAuth = &db.GenericOAuth{
+				AuthURLParams: map[string]string{"param1": "value1", "param2": "value2"},
+			}
+		})
+
+		It("constructs the Auth URL with the configured Auth URL params", func() {
+			authURI := goaProvider.AuthCodeURL(state, []oauth2.AuthCodeOption{}...)
+
+			Expect(authURI).To(ContainSubstring("param1=value1"))
+			Expect(authURI).To(ContainSubstring("param2=value2"))
+		})
+
+		It("merges the passed in Auth URL params with the configured Auth URL params", func() {
+			authURI := goaProvider.AuthCodeURL(state, []oauth2.AuthCodeOption{oauth2.SetAuthURLParam("param3", "value3")}...)
+
+			Expect(authURI).To(ContainSubstring("param1=value1"))
+			Expect(authURI).To(ContainSubstring("param2=value2"))
+			Expect(authURI).To(ContainSubstring("param3=value3"))
+		})
+
+		It("URL encodes the Auth URL params", func() {
+			authURI := goaProvider.AuthCodeURL(state, []oauth2.AuthCodeOption{oauth2.SetAuthURLParam("question#1", "are your tests passing?")}...)
+
+			Expect(authURI).To(ContainSubstring("question%231=are+your+tests+passing%3F"))
+		})
+
+	})
+})

--- a/auth/provider/oauth_factory.go
+++ b/auth/provider/oauth_factory.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"code.cloudfoundry.org/gunk/urljoiner"
 	"code.cloudfoundry.org/lager"
+	"github.com/concourse/atc/auth/genericoauth"
 	"github.com/concourse/atc/auth/github"
 	"github.com/concourse/atc/auth/uaa"
 	"github.com/concourse/atc/db"
@@ -49,6 +50,13 @@ func (of OAuthFactory) GetProvider(team db.SavedTeam, providerName string) (Prov
 		}
 
 		return uaa.NewProvider(team.UAAAuth, urljoiner.Join(of.atcExternalURL, redirectURL)), true, nil
+
+	case genericoauth.ProviderName:
+		if team.GenericOAuth == nil {
+			return nil, false, nil
+		}
+
+		return genericoauth.NewProvider(team.GenericOAuth, urljoiner.Join(of.atcExternalURL, redirectURL)), true, nil
 
 	}
 

--- a/auth/provider/oauth_factory_test.go
+++ b/auth/provider/oauth_factory_test.go
@@ -3,6 +3,7 @@ package provider_test
 import (
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/atc/auth"
+	"github.com/concourse/atc/auth/genericoauth"
 	"github.com/concourse/atc/auth/github"
 	"github.com/concourse/atc/auth/provider"
 	"github.com/concourse/atc/auth/uaa"
@@ -82,6 +83,37 @@ var _ = Describe("OAuthFactory", func() {
 							Name: "some-team",
 						},
 					}, uaa.ProviderName)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(found).To(BeFalse())
+				})
+			})
+		})
+
+		Context("when asking for goa provider", func() {
+			Context("when Generic OAuth provider is setup", func() {
+				It("returns back GOA's auth provider", func() {
+					provider, found, err := oauthFactory.GetProvider(db.SavedTeam{
+						Team: db.Team{
+							Name: "some-team",
+							GenericOAuth: &db.GenericOAuth{
+								ClientID:     "user1",
+								ClientSecret: "password1",
+							},
+						},
+					}, genericoauth.ProviderName)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(provider).NotTo(BeNil())
+				})
+			})
+
+			Context("when Generic OAuth provider is not setup", func() {
+				It("returns false", func() {
+					_, found, err := oauthFactory.GetProvider(db.SavedTeam{
+						Team: db.Team{
+							Name: "some-team",
+						},
+					}, genericoauth.ProviderName)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeFalse())
 				})

--- a/auth/provider/oauth_factory_test.go
+++ b/auth/provider/oauth_factory_test.go
@@ -89,7 +89,7 @@ var _ = Describe("OAuthFactory", func() {
 			})
 		})
 
-		Context("when asking for goa provider", func() {
+		Context("when asking for generic oauth", func() {
 			Context("when Generic OAuth provider is setup", func() {
 				It("returns back GOA's auth provider", func() {
 					provider, found, err := oauthFactory.GetProvider(db.SavedTeam{
@@ -104,25 +104,6 @@ var _ = Describe("OAuthFactory", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(provider).NotTo(BeNil())
-				})
-			})
-
-			Context("when asking for generic oauth", func() {
-				Context("when Generic OAuth provider is setup", func() {
-					It("returns back GOA's auth provider", func() {
-						providers, err := oauthFactory.GetProviders(db.SavedTeam{
-							Team: db.Team{
-								Name: "some-team",
-								GenericOAuth: &db.GenericOAuth{
-									ClientID:     "user1",
-									ClientSecret: "password1",
-								},
-							},
-						})
-						Expect(err).NotTo(HaveOccurred())
-						Expect(providers).To(HaveLen(1))
-						Expect(providers[genericoauth.ProviderName]).NotTo(BeNil())
-					})
 				})
 
 				Context("when Generic OAuth provider is not setup", func() {

--- a/auth/provider/oauth_factory_test.go
+++ b/auth/provider/oauth_factory_test.go
@@ -107,15 +107,34 @@ var _ = Describe("OAuthFactory", func() {
 				})
 			})
 
-			Context("when Generic OAuth provider is not setup", func() {
-				It("returns false", func() {
-					_, found, err := oauthFactory.GetProvider(db.SavedTeam{
-						Team: db.Team{
-							Name: "some-team",
-						},
-					}, genericoauth.ProviderName)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeFalse())
+			Context("when asking for generic oauth", func() {
+				Context("when Generic OAuth provider is setup", func() {
+					It("returns back GOA's auth provider", func() {
+						providers, err := oauthFactory.GetProviders(db.SavedTeam{
+							Team: db.Team{
+								Name: "some-team",
+								GenericOAuth: &db.GenericOAuth{
+									ClientID:     "user1",
+									ClientSecret: "password1",
+								},
+							},
+						})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(providers).To(HaveLen(1))
+						Expect(providers[genericoauth.ProviderName]).NotTo(BeNil())
+					})
+				})
+
+				Context("when Generic OAuth provider is not setup", func() {
+					It("returns false", func() {
+						_, found, err := oauthFactory.GetProvider(db.SavedTeam{
+							Team: db.Team{
+								Name: "some-team",
+							},
+						}, genericoauth.ProviderName)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(found).To(BeFalse())
+					})
 				})
 			})
 		})

--- a/db/db_teams_test.go
+++ b/db/db_teams_test.go
@@ -93,9 +93,22 @@ var _ = Describe("SQL DB Teams", func() {
 			savedTeam3, err := database.CreateTeam(team3)
 			Expect(err).NotTo(HaveOccurred())
 
+			team4 := db.Team{
+				Name: "cyborgs",
+				GenericOAuth: &db.GenericOAuth{
+					DisplayName:   "Cyborgs",
+					ClientID:      "some random guid",
+					ClientSecret:  "don't tell anyone",
+					AuthURL:       "https://auth.url",
+					AuthURLParams: map[string]string{"allow_humans": "false"},
+				},
+			}
+			savedTeam4, err := database.CreateTeam(team4)
+			Expect(err).NotTo(HaveOccurred())
+
 			actualTeams, err := database.GetTeams()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(actualTeams).To(ConsistOf(savedTeam1, savedTeam2, savedTeam3))
+			Expect(actualTeams).To(ConsistOf(savedTeam1, savedTeam2, savedTeam3, savedTeam4))
 		})
 	})
 
@@ -158,6 +171,7 @@ var _ = Describe("SQL DB Teams", func() {
 			Expect(expectedSavedTeam.Team.BasicAuth).To(Equal(expectedTeam.BasicAuth))
 			Expect(expectedSavedTeam.Team.GitHubAuth).To(Equal(expectedTeam.GitHubAuth))
 			Expect(expectedSavedTeam.Team.UAAAuth).To(Equal(expectedTeam.UAAAuth))
+			Expect(expectedSavedTeam.Team.GenericOAuth).To(Equal(expectedTeam.GenericOAuth))
 			Expect(expectedSavedTeam.Team.Name).To(Equal("AvengerS"))
 
 			savedTeam, found, err := teamDBFactory.GetTeamDB("aVengers").GetTeam()
@@ -242,6 +256,29 @@ var _ = Describe("SQL DB Teams", func() {
 			Expect(savedTeam).To(Equal(expectedSavedTeam))
 
 			Expect(savedTeam.UAAAuth).To(Equal(expectedTeam.UAAAuth))
+		})
+
+		It("saves a team to the db with Generic OAuth auth", func() {
+			expectedTeam := db.Team{
+				Name: "cyborgs",
+				GenericOAuth: &db.GenericOAuth{
+					DisplayName:   "Cyborgs",
+					ClientID:      "some random guid",
+					ClientSecret:  "don't tell anyone",
+					AuthURL:       "https://auth.url",
+					AuthURLParams: map[string]string{"allow_humans": "false"},
+				},
+			}
+			expectedSavedTeam, err := database.CreateTeam(expectedTeam)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(expectedSavedTeam.Team).To(Equal(expectedTeam))
+
+			savedTeam, found, err := teamDBFactory.GetTeamDB("cyborgs").GetTeam()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(savedTeam).To(Equal(expectedSavedTeam))
+
+			Expect(savedTeam.GenericOAuth).To(Equal(expectedTeam.GenericOAuth))
 		})
 	})
 

--- a/db/dbfakes/fake_team_db.go
+++ b/db/dbfakes/fake_team_db.go
@@ -83,6 +83,16 @@ type FakeTeamDB struct {
 		result1 db.SavedTeam
 		result2 error
 	}
+	UpdateGenericOAuthStub        func(genericOAuth *db.GenericOAuth) (db.SavedTeam, error)
+	updateGenericOAuthMutex       sync.RWMutex
+	updateGenericOAuthArgsForCall []struct {
+		genericOAuth *db.GenericOAuth
+	}
+	updateGenericOAuthReturns struct {
+		result1 db.SavedTeam
+		result2 error
+	}
+
 	GetConfigStub        func(pipelineName string) (atc.Config, atc.RawConfig, db.ConfigVersion, error)
 	getConfigMutex       sync.RWMutex
 	getConfigArgsForCall []struct {
@@ -436,6 +446,40 @@ func (fake *FakeTeamDB) UpdateUAAAuthArgsForCall(i int) *db.UAAAuth {
 func (fake *FakeTeamDB) UpdateUAAAuthReturns(result1 db.SavedTeam, result2 error) {
 	fake.UpdateUAAAuthStub = nil
 	fake.updateUAAAuthReturns = struct {
+		result1 db.SavedTeam
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTeamDB) UpdateGenericOAuth(genericOAuth *db.GenericOAuth) (db.SavedTeam, error) {
+	fake.updateGenericOAuthMutex.Lock()
+	fake.updateGenericOAuthArgsForCall = append(fake.updateGenericOAuthArgsForCall, struct {
+		genericOAuth *db.GenericOAuth
+	}{genericOAuth})
+	fake.recordInvocation("UpdateGenericOAuth", []interface{}{genericOAuth})
+	fake.updateGenericOAuthMutex.Unlock()
+	if fake.UpdateGenericOAuthStub != nil {
+		return fake.UpdateGenericOAuthStub(genericOAuth)
+	} else {
+		return fake.updateGenericOAuthReturns.result1, fake.updateGenericOAuthReturns.result2
+	}
+}
+
+func (fake *FakeTeamDB) UpdateGenericOAuthCallCount() int {
+	fake.updateGenericOAuthMutex.RLock()
+	defer fake.updateGenericOAuthMutex.RUnlock()
+	return len(fake.updateGenericOAuthArgsForCall)
+}
+
+func (fake *FakeTeamDB) UpdateGenericOAuthArgsForCall(i int) *db.GenericOAuth {
+	fake.updateGenericOAuthMutex.RLock()
+	defer fake.updateGenericOAuthMutex.RUnlock()
+	return fake.updateGenericOAuthArgsForCall[i].genericOAuth
+}
+
+func (fake *FakeTeamDB) UpdateGenericOAuthReturns(result1 db.SavedTeam, result2 error) {
+	fake.UpdateGenericOAuthStub = nil
+	fake.updateGenericOAuthReturns = struct {
 		result1 db.SavedTeam
 		result2 error
 	}{result1, result2}

--- a/db/dbfakes/fake_team_db.go
+++ b/db/dbfakes/fake_team_db.go
@@ -762,6 +762,8 @@ func (fake *FakeTeamDB) Invocations() map[string][][]interface{} {
 	defer fake.updateGitHubAuthMutex.RUnlock()
 	fake.updateUAAAuthMutex.RLock()
 	defer fake.updateUAAAuthMutex.RUnlock()
+	fake.updateGenericOAuthMutex.RLock()
+	defer fake.updateGenericOAuthMutex.RUnlock()
 	fake.getConfigMutex.RLock()
 	defer fake.getConfigMutex.RUnlock()
 	fake.saveConfigMutex.RLock()

--- a/db/migrations/120_add_generic_oauth_to_teams.go
+++ b/db/migrations/120_add_generic_oauth_to_teams.go
@@ -1,0 +1,11 @@
+package migrations
+
+import "github.com/BurntSushi/migration"
+
+func AddGenericOAuthToTeams(tx migration.LimitedTx) error {
+	_, err := tx.Exec(`
+    ALTER TABLE teams
+    ADD COLUMN genericoauth_auth json null;
+	`)
+	return err
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -120,4 +120,5 @@ var Migrations = []migration.Migrator{
 	AddNextBuildInputs,
 	AddCaseInsenstiveUniqueIndexToTeamsName,
 	AddNonEmptyConstraintToTeamName,
+	AddGenericOAuthToTeams,
 }

--- a/db/team.go
+++ b/db/team.go
@@ -10,9 +10,10 @@ type Team struct {
 	Name  string
 	Admin bool
 
-	BasicAuth  *BasicAuth  `json:"basic_auth"`
-	GitHubAuth *GitHubAuth `json:"github_auth"`
-	UAAAuth    *UAAAuth    `json:"uaa_auth"`
+	BasicAuth    *BasicAuth    `json:"basic_auth"`
+	GitHubAuth   *GitHubAuth   `json:"github_auth"`
+	UAAAuth      *UAAAuth      `json:"uaa_auth"`
+	GenericOAuth *GenericOAuth `json:"genericoauth_auth"`
 }
 
 func (t Team) IsAuthConfigured() bool {
@@ -70,4 +71,13 @@ type UAAAuth struct {
 	CFSpaces     []string `json:"cf_spaces"`
 	CFURL        string   `json:"cf_url"`
 	CFCACert     string   `json:"cf_ca_cert"`
+}
+
+type GenericOAuth struct {
+	AuthURL       string            `json:"auth_url"`
+	AuthURLParams map[string]string `json:"auth_url_params"`
+	TokenURL      string            `json:"token_url"`
+	ClientID      string            `json:"client_id"`
+	ClientSecret  string            `json:"client_secret"`
+	DisplayName   string            `json:"display_name"`
 }

--- a/db/team_db.go
+++ b/db/team_db.go
@@ -26,6 +26,7 @@ type TeamDB interface {
 	UpdateBasicAuth(basicAuth *BasicAuth) (SavedTeam, error)
 	UpdateGitHubAuth(gitHubAuth *GitHubAuth) (SavedTeam, error)
 	UpdateUAAAuth(uaaAuth *UAAAuth) (SavedTeam, error)
+	UpdateGenericOAuth(genericOAuth *GenericOAuth) (SavedTeam, error)
 
 	GetConfig(pipelineName string) (atc.Config, atc.RawConfig, ConfigVersion, error)
 	SaveConfig(string, atc.Config, ConfigVersion, PipelinePausedState) (SavedPipeline, bool, error)
@@ -450,7 +451,7 @@ func (db *teamDB) registerResourceType(tx Tx, resourceType atc.ResourceType, pip
 
 func (db *teamDB) GetTeam() (SavedTeam, bool, error) {
 	query := `
-		SELECT id, name, admin, basic_auth, github_auth, uaa_auth
+		SELECT id, name, admin, basic_auth, github_auth, uaa_auth, genericoauth_auth
 		FROM teams
 		WHERE LOWER(name) = LOWER($1)
 	`
@@ -468,7 +469,7 @@ func (db *teamDB) GetTeam() (SavedTeam, bool, error) {
 }
 
 func (db *teamDB) queryTeam(query string, params []interface{}) (SavedTeam, error) {
-	var basicAuth, gitHubAuth, uaaAuth sql.NullString
+	var basicAuth, gitHubAuth, uaaAuth, genericOAuth sql.NullString
 	var savedTeam SavedTeam
 
 	tx, err := db.conn.Begin()
@@ -484,6 +485,7 @@ func (db *teamDB) queryTeam(query string, params []interface{}) (SavedTeam, erro
 		&basicAuth,
 		&gitHubAuth,
 		&uaaAuth,
+		&genericOAuth,
 	)
 	if err != nil {
 		return savedTeam, err
@@ -514,6 +516,13 @@ func (db *teamDB) queryTeam(query string, params []interface{}) (SavedTeam, erro
 		}
 	}
 
+	if genericOAuth.Valid {
+		err = json.Unmarshal([]byte(genericOAuth.String), &savedTeam.GenericOAuth)
+		if err != nil {
+			return savedTeam, err
+		}
+	}
+
 	return savedTeam, nil
 }
 
@@ -527,7 +536,7 @@ func (db *teamDB) UpdateBasicAuth(basicAuth *BasicAuth) (SavedTeam, error) {
 		UPDATE teams
 		SET basic_auth = $1
 		WHERE LOWER(name) = LOWER($2)
-		RETURNING id, name, admin, basic_auth, github_auth, uaa_auth
+		RETURNING id, name, admin, basic_auth, github_auth, uaa_auth, genericoauth_auth
 	`
 
 	params := []interface{}{encryptedBasicAuth, db.teamName}
@@ -549,7 +558,7 @@ func (db *teamDB) UpdateGitHubAuth(gitHubAuth *GitHubAuth) (SavedTeam, error) {
 		UPDATE teams
 		SET github_auth = $1
 		WHERE LOWER(name) = LOWER($2)
-		RETURNING id, name, admin, basic_auth, github_auth, uaa_auth
+		RETURNING id, name, admin, basic_auth, github_auth, uaa_auth, genericoauth_auth
 	`
 	params := []interface{}{string(jsonEncodedGitHubAuth), db.teamName}
 	return db.queryTeam(query, params)
@@ -565,9 +574,25 @@ func (db *teamDB) UpdateUAAAuth(uaaAuth *UAAAuth) (SavedTeam, error) {
 		UPDATE teams
 		SET uaa_auth = $1
 		WHERE LOWER(name) = LOWER($2)
-		RETURNING id, name, admin, basic_auth, github_auth, uaa_auth
+		RETURNING id, name, admin, basic_auth, github_auth, uaa_auth, genericoauth_auth
 	`
 	params := []interface{}{string(jsonEncodedUAAAuth), db.teamName}
+	return db.queryTeam(query, params)
+}
+
+func (db *teamDB) UpdateGenericOAuth(genericOAuth *GenericOAuth) (SavedTeam, error) {
+	jsonEncodedGenericOAuth, err := json.Marshal(genericOAuth)
+	if err != nil {
+		return SavedTeam{}, err
+	}
+
+	query := `
+		UPDATE teams
+		SET genericoauth_auth = $1
+		WHERE LOWER(name) = LOWER($2)
+		RETURNING id, name, admin, basic_auth, github_auth, uaa_auth, genericoauth_auth
+	`
+	params := []interface{}{string(jsonEncodedGenericOAuth), db.teamName}
 	return db.queryTeam(query, params)
 }
 

--- a/db/team_db_test.go
+++ b/db/team_db_test.go
@@ -267,6 +267,7 @@ var _ = Describe("TeamDB", func() {
 		var basicAuth *db.BasicAuth
 		var gitHubAuth *db.GitHubAuth
 		var uaaAuth *db.UAAAuth
+		var genericOAuth *db.GenericOAuth
 
 		BeforeEach(func() {
 			basicAuth = &db.BasicAuth{
@@ -299,6 +300,15 @@ var _ = Describe("TeamDB", func() {
 				CFSpaces:     []string{"a", "b", "c"},
 				CFURL:        "https://some.api.url",
 			}
+
+			genericOAuth = &db.GenericOAuth{
+				DisplayName:   "Cyborgs",
+				ClientID:      "some random guid",
+				ClientSecret:  "don't tell anyone",
+				AuthURL:       "https://auth.url",
+				AuthURLParams: map[string]string{"option": "1"},
+				TokenURL:      "https://token.url",
+			}
 		})
 
 		Describe("UpdateBasicAuth", func() {
@@ -320,6 +330,16 @@ var _ = Describe("TeamDB", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(savedTeam.UAAAuth).To(Equal(uaaAuth))
+			})
+
+			It("saves basic auth team info without overwriting the Generic OAuth info", func() {
+				_, err := teamDB.UpdateGenericOAuth(genericOAuth)
+				Expect(err).NotTo(HaveOccurred())
+
+				savedTeam, err := teamDB.UpdateBasicAuth(basicAuth)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(savedTeam.GenericOAuth).To(Equal(genericOAuth))
 			})
 
 			It("saves basic auth team info to the existing team", func() {
@@ -393,6 +413,16 @@ var _ = Describe("TeamDB", func() {
 
 				Expect(savedTeam.UAAAuth).To(Equal(uaaAuth))
 			})
+
+			It("saves github auth team info without over writing the Generic OAuth info", func() {
+				_, err := teamDB.UpdateGenericOAuth(genericOAuth)
+				Expect(err).NotTo(HaveOccurred())
+
+				savedTeam, err := teamDB.UpdateGitHubAuth(gitHubAuth)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(savedTeam.GenericOAuth).To(Equal(genericOAuth))
+			})
 		})
 
 		Describe("UpdateUAAAuth", func() {
@@ -401,6 +431,14 @@ var _ = Describe("TeamDB", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(savedTeam.UAAAuth).To(Equal(uaaAuth))
+			})
+		})
+
+		Describe("UpdateGenericOAuth", func() {
+			It("saves generic oauth info to the existing team", func() {
+				savedTeam, err := teamDB.UpdateGenericOAuth(genericOAuth)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(savedTeam.GenericOAuth).To(Equal(genericOAuth))
 			})
 		})
 	})

--- a/team.go
+++ b/team.go
@@ -8,9 +8,10 @@ type Team struct {
 	// Name is the team's name
 	Name string `json:"name,omitempty"`
 
-	BasicAuth  *BasicAuth  `json:"basic_auth,omitempty"`
-	GitHubAuth *GitHubAuth `json:"github_auth,omitempty"`
-	UAAAuth    *UAAAuth    `json:"uaa_auth,omitempty"`
+	BasicAuth    *BasicAuth    `json:"basic_auth,omitempty"`
+	GitHubAuth   *GitHubAuth   `json:"github_auth,omitempty"`
+	UAAAuth      *UAAAuth      `json:"uaa_auth,omitempty"`
+	GenericOAuth *GenericOAuth `json:"genericoauth_auth,omitempty"`
 }
 
 type BasicAuth struct {
@@ -42,4 +43,13 @@ type UAAAuth struct {
 	CFSpaces     []string `json:"cf_spaces,omitempty"`
 	CFURL        string   `json:"cf_url,omitempty"`
 	CFCACert     string   `json:"cf_ca_cert,omitempty"`
+}
+
+type GenericOAuth struct {
+	AuthURL       string            `json:"auth_url,omitempty"`
+	AuthURLParams map[string]string `json:"auth_url_params,omitempty"`
+	TokenURL      string            `json:"token_url,omitempty"`
+	ClientID      string            `json:"client_id,omitempty"`
+	ClientSecret  string            `json:"client_secret,omitempty"`
+	DisplayName   string            `json:"display_name,omitempty"`
 }


### PR DESCRIPTION
(following on from https://github.com/concourse/atc/pull/99)

The option allows all authorized users from the given auth provider. See https://github.com/concourse/concourse/issues/539.

Use it by specifying the following on the command line:
```
concourse
  --generic-oauth-client-id=abc \
  --generic-oauth-client-secret=123 \
  --generic-oauth-auth-url=https://github.com/login/outh/authorize \
  --generic-oauth-auth-param=param1:value1 \
  --generic-oauth-token-url=https://github.com/login/oauth/access_token \
  --generic-oauth-display-name=Githubz
```

This will present a login prompt on the web ui like:
![image](https://cloud.githubusercontent.com/assets/4723538/17664120/2b2c3110-6335-11e6-8ed3-9f5e1c10d9d3.png)


I've verified that it works with GitHub.

Added support for a configurable display name.

Added support for passing arbitrary values through to the auth URL endpoint.

Added acceptance test scenarios.