### PR TITLE
add parameter to change cookie expire duration

### DIFF
--- a/api/api_suite_test.go
+++ b/api/api_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
@@ -63,6 +64,7 @@ var (
 	configValidationWarnings      []config.Warning
 	peerAddr                      string
 	drain                         chan struct{}
+	expire                        time.Duration
 	cliDownloadsDir               string
 	logger                        *lagertest.TestLogger
 
@@ -134,6 +136,8 @@ var _ = BeforeEach(func() {
 	sink = lager.NewReconfigurableSink(lager.NewWriterSink(GinkgoWriter, lager.DEBUG), lager.DEBUG)
 	logger.RegisterSink(sink)
 
+	expire = 24 * time.Hour
+
 	build = new(dbfakes.FakeBuild)
 
 	checkPipelineAccessHandlerFactory := auth.NewCheckPipelineAccessHandlerFactory(pipelineDBFactory, teamDBFactory)
@@ -185,6 +189,8 @@ var _ = BeforeEach(func() {
 		fakeScannerFactory,
 
 		sink,
+
+		expire,
 
 		cliDownloadsDir,
 		"1.2.3",

--- a/api/authserver/get_auth_token.go
+++ b/api/authserver/get_auth_token.go
@@ -11,8 +11,6 @@ import (
 	"github.com/concourse/atc/auth"
 )
 
-const tokenDuration = 24 * time.Hour
-
 func (s *Server) GetAuthToken(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.Session("get-auth-token")
 	logger.Debug("getting-auth-token")
@@ -41,7 +39,7 @@ func (s *Server) GetAuthToken(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		tokenType, tokenValue, err := s.tokenGenerator.GenerateToken(time.Now().Add(tokenDuration), team.Name, team.ID, team.Admin)
+		tokenType, tokenValue, err := s.tokenGenerator.GenerateToken(time.Now().Add(s.expire), team.Name, team.ID, team.Admin)
 		if err != nil {
 			logger.Error("generate-token", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/api/authserver/server.go
+++ b/api/authserver/server.go
@@ -1,6 +1,8 @@
 package authserver
 
 import (
+	"time"
+
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/atc/auth"
 	"github.com/concourse/atc/db"
@@ -13,6 +15,7 @@ type Server struct {
 	tokenGenerator  auth.TokenGenerator
 	providerFactory auth.ProviderFactory
 	teamDBFactory   db.TeamDBFactory
+	expire          time.Duration
 }
 
 func NewServer(
@@ -22,6 +25,7 @@ func NewServer(
 	tokenGenerator auth.TokenGenerator,
 	providerFactory auth.ProviderFactory,
 	teamDBFactory db.TeamDBFactory,
+	expire time.Duration,
 ) *Server {
 	return &Server{
 		logger:          logger,
@@ -30,5 +34,6 @@ func NewServer(
 		tokenGenerator:  tokenGenerator,
 		providerFactory: providerFactory,
 		teamDBFactory:   teamDBFactory,
+		expire:          expire,
 	}
 }

--- a/api/handler.go
+++ b/api/handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"path/filepath"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/tedsuo/rata"
@@ -65,6 +66,8 @@ func NewHandler(
 
 	sink *lager.ReconfigurableSink,
 
+	expire time.Duration,
+
 	cliDownloadsDir string,
 	version string,
 ) (http.Handler, error) {
@@ -84,6 +87,7 @@ func NewHandler(
 		tokenGenerator,
 		providerFactory,
 		teamDBFactory,
+		expire,
 	)
 
 	buildServer := buildserver.NewServer(

--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -873,6 +873,8 @@ func (cmd *ATCCommand) constructAPIHandler(
 
 		reconfigurableSink,
 
+		cmd.AuthExpire,
+
 		cmd.CLIArtifactsDir.Path(),
 		Version,
 	)

--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -65,6 +65,7 @@ type ATCCommand struct {
 	PeerURL     URLFlag `long:"peer-url"     default:"http://127.0.0.1:8080" description:"URL used to reach this ATC from other ATCs in the cluster."`
 
 	OAuthBaseURL URLFlag `long:"oauth-base-url" description:"URL used as the base of OAuth redirect URIs. If not specified, the external URL is used."`
+	AuthExpire time.Duration `long:"auth-expire" default:"24h" description:"Authorization Expiration Duration."`
 
 	PostgresDataSource string `long:"postgres-data-source" default:"postgres://127.0.0.1:5432/atc?sslmode=disable" description:"PostgreSQL connection string."`
 
@@ -224,6 +225,7 @@ func (cmd *ATCCommand) Runner(args []string) (ifrit.Runner, error) {
 		providerFactory,
 		teamDBFactory,
 		signingKey,
+		cmd.AuthExpire,
 	)
 	if err != nil {
 		return nil, err
@@ -233,6 +235,7 @@ func (cmd *ATCCommand) Runner(args []string) (ifrit.Runner, error) {
 		logger,
 		wrappa.NewWebMetricsWrappa(logger),
 		web.NewClientFactory(cmd.internalURL(), cmd.AllowSelfSignedCertificates || cmd.Developer.DevelopmentMode),
+		cmd.AuthExpire,
 	)
 	if err != nil {
 		return nil, err

--- a/auth/cookie_set_handler.go
+++ b/auth/cookie_set_handler.go
@@ -2,11 +2,9 @@ package auth
 
 import (
 	"net/http"
-	"time"
 )
 
 const CookieName = "ATC-Authorization"
-const CookieAge = 24 * time.Hour
 
 type CookieSetHandler struct {
 	Handler http.Handler

--- a/auth/logout_handler_test.go
+++ b/auth/logout_handler_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rsa"
 	"net/http"
 	"net/http/httptest"
+	"time"
+
 
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"
@@ -32,12 +34,14 @@ var _ = Describe("LogOutHandler", func() {
 			fakeTeamDBFactory := new(dbfakes.FakeTeamDBFactory)
 			signingKey, err = rsa.GenerateKey(rand.Reader, 1024)
 			Expect(err).ToNot(HaveOccurred())
+			expire = 24 * time.Hour
 
 			handler, err := auth.NewOAuthHandler(
 				lagertest.NewTestLogger("test"),
 				fakeProviderFactory,
 				fakeTeamDBFactory,
 				signingKey,
+				expire,
 			)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/auth/logout_handler_test.go
+++ b/auth/logout_handler_test.go
@@ -27,6 +27,7 @@ var _ = Describe("LogOutHandler", func() {
 			request             *http.Request
 			response            *http.Response
 			err                 error
+			expire              time.Duration
 		)
 
 		BeforeEach(func() {

--- a/auth/oauth_begin_handler.go
+++ b/auth/oauth_begin_handler.go
@@ -24,6 +24,7 @@ type OAuthBeginHandler struct {
 	providerFactory ProviderFactory
 	privateKey      *rsa.PrivateKey
 	teamDBFactory   db.TeamDBFactory
+	expire          time.Duration
 }
 
 func NewOAuthBeginHandler(
@@ -31,12 +32,14 @@ func NewOAuthBeginHandler(
 	providerFactory ProviderFactory,
 	privateKey *rsa.PrivateKey,
 	teamDBFactory db.TeamDBFactory,
+	expire time.Duration,
 ) http.Handler {
 	return &OAuthBeginHandler{
 		logger:          logger,
 		providerFactory: providerFactory,
 		privateKey:      privateKey,
 		teamDBFactory:   teamDBFactory,
+		expire:          expire,
 	}
 }
 
@@ -100,7 +103,7 @@ func (handler *OAuthBeginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		Name:    OAuthStateCookie,
 		Value:   encodedState,
 		Path:    "/",
-		Expires: time.Now().Add(CookieAge),
+		Expires: time.Now().Add(handler.expire),
 	})
 
 	http.Redirect(w, r, authCodeURL, http.StatusTemporaryRedirect)

--- a/auth/oauth_begin_handler_test.go
+++ b/auth/oauth_begin_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"time"
 
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"
@@ -51,6 +52,7 @@ var _ = Describe("OAuthBeginHandler", func() {
 		var err error
 		signingKey, err = rsa.GenerateKey(rand.Reader, 1024)
 		Expect(err).ToNot(HaveOccurred())
+		expire = 24 * time.Hour
 
 		fakeTeamDBFactory = new(dbfakes.FakeTeamDBFactory)
 		fakeTeamDBFactory.GetTeamDBReturns(fakeTeamDB)
@@ -59,6 +61,7 @@ var _ = Describe("OAuthBeginHandler", func() {
 			fakeProviderFactory,
 			fakeTeamDBFactory,
 			signingKey,
+			expire,
 		)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/auth/oauth_begin_handler_test.go
+++ b/auth/oauth_begin_handler_test.go
@@ -36,6 +36,8 @@ var _ = Describe("OAuthBeginHandler", func() {
 
 		signingKey *rsa.PrivateKey
 
+		expire time.Duration
+
 		cookieJar *cookiejar.Jar
 
 		server *httptest.Server

--- a/auth/oauth_callback_handler.go
+++ b/auth/oauth_callback_handler.go
@@ -21,6 +21,7 @@ type OAuthCallbackHandler struct {
 	privateKey      *rsa.PrivateKey
 	tokenGenerator  TokenGenerator
 	teamDBFactory   db.TeamDBFactory
+	expire          time.Duration
 }
 
 func NewOAuthCallbackHandler(
@@ -28,6 +29,7 @@ func NewOAuthCallbackHandler(
 	providerFactory ProviderFactory,
 	privateKey *rsa.PrivateKey,
 	teamDBFactory db.TeamDBFactory,
+	expire time.Duration,
 ) http.Handler {
 	return &OAuthCallbackHandler{
 		logger:          logger,
@@ -35,6 +37,7 @@ func NewOAuthCallbackHandler(
 		privateKey:      privateKey,
 		tokenGenerator:  NewTokenGenerator(privateKey),
 		teamDBFactory:   teamDBFactory,
+		expire:          expire,
 	}
 }
 
@@ -154,7 +157,7 @@ func (handler *OAuthCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	exp := time.Now().Add(CookieAge)
+	exp := time.Now().Add(handler.expire)
 
 	tokenType, signedToken, err := handler.tokenGenerator.GenerateToken(exp, team.Name, team.ID, team.Admin)
 	if err != nil {

--- a/auth/oauth_callback_handler_test.go
+++ b/auth/oauth_callback_handler_test.go
@@ -216,7 +216,7 @@ var _ = Describe("OAuthCallbackHandler", func() {
 
 							It("set to a signed token that expires in 1 day", func() {
 								Expect(cookie.Name).To(Equal(auth.CookieName))
-								Expect(cookie.Expires).To(BeTemporally("~", time.Now().Add(auth.CookieAge), 5*time.Second))
+								Expect(cookie.Expires).To(BeTemporally("~", time.Now().Add(24*time.Hour), 5*time.Second))
 
 								Expect(cookie.Value).To(MatchRegexp(`^Bearer .*`))
 

--- a/auth/oauth_callback_handler_test.go
+++ b/auth/oauth_callback_handler_test.go
@@ -41,6 +41,8 @@ var _ = Describe("OAuthCallbackHandler", func() {
 
 		signingKey *rsa.PrivateKey
 
+		expire time.Duration
+
 		server *httptest.Server
 		client *http.Client
 

--- a/auth/oauth_callback_handler_test.go
+++ b/auth/oauth_callback_handler_test.go
@@ -55,6 +55,7 @@ var _ = Describe("OAuthCallbackHandler", func() {
 		var err error
 		signingKey, err = rsa.GenerateKey(rand.Reader, 1024)
 		Expect(err).ToNot(HaveOccurred())
+		expire = 24 * time.Hour
 
 		fakeProviderFactory.GetProviderStub = func(team db.SavedTeam, providerName string) (provider.Provider, bool, error) {
 			if providerName == "some-provider" {
@@ -82,6 +83,7 @@ var _ = Describe("OAuthCallbackHandler", func() {
 			fakeProviderFactory,
 			fakeTeamDBFactory,
 			signingKey,
+			expire,
 		)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/auth/oauth_handler.go
+++ b/auth/oauth_handler.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"net/http"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/atc/auth/provider"
@@ -25,6 +26,7 @@ func NewOAuthHandler(
 	providerFactory ProviderFactory,
 	teamDBFactory db.TeamDBFactory,
 	signingKey *rsa.PrivateKey,
+	expire time.Duration,
 ) (http.Handler, error) {
 	return rata.NewRouter(
 		OAuthRoutes,
@@ -34,12 +36,14 @@ func NewOAuthHandler(
 				providerFactory,
 				signingKey,
 				teamDBFactory,
+				expire,
 			),
 			OAuthCallback: NewOAuthCallbackHandler(
 				logger.Session("oauth-callback"),
 				providerFactory,
 				signingKey,
 				teamDBFactory,
+				expire,
 			),
 			LogOut: NewLogOutHandler(
 				logger.Session("logout"),

--- a/web/login/process_handler.go
+++ b/web/login/process_handler.go
@@ -11,20 +11,22 @@ import (
 )
 
 const CookieName = "ATC-Authorization"
-const CookieAge = 24 * time.Hour
 
 type processHandler struct {
 	logger        lager.Logger
 	clientFactory web.ClientFactory
+	expire        time.Duration
 }
 
 func NewProcessBasicAuthHandler(
 	logger lager.Logger,
 	clientFactory web.ClientFactory,
+	expire time.Duration,
 ) http.Handler {
 	return &processHandler{
 		logger:        logger,
 		clientFactory: clientFactory,
+		expire:        expire,
 	}
 }
 
@@ -59,7 +61,7 @@ func (h *processHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Name:    CookieName,
 		Value:   fmt.Sprintf("%s %s", token.Type, token.Value),
 		Path:    "/",
-		Expires: time.Now().Add(CookieAge),
+		Expires: time.Now().Add(h.expire),
 	})
 
 	http.Redirect(w, r, redirect, http.StatusFound)

--- a/web/webhandler/handler.go
+++ b/web/webhandler/handler.go
@@ -3,6 +3,7 @@ package webhandler
 import (
 	"html/template"
 	"net/http"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/elazarl/go-bindata-assetfs"
@@ -27,6 +28,7 @@ func NewHandler(
 	logger lager.Logger,
 	wrapper wrappa.Wrappa,
 	clientFactory web.ClientFactory,
+	expire time.Duration,
 ) (http.Handler, error) {
 	tfuncs := &templateFuncs{
 		assetIDs: map[string]string{},
@@ -98,7 +100,7 @@ func NewHandler(
 		web.TriggerBuild:          authredirect.Handler{triggerbuild.NewHandler(logger, clientFactory)},
 		web.TeamLogIn:             login.NewHandler(logger, logInTemplate),
 		web.LogIn:                 login.NewHandler(logger, logInTemplate),
-		web.ProcessBasicAuthLogIn: login.NewProcessBasicAuthHandler(logger, clientFactory),
+		web.ProcessBasicAuthLogIn: login.NewProcessBasicAuthHandler(logger, clientFactory, expire),
 
 		web.MainPipeline:    mainwrapper.Handler{web.Pipeline, authredirect.Handler{pipelineHandler}},
 		web.MainGetJob:      mainwrapper.Handler{web.GetJob, authredirect.Handler{getjob.NewHandler(logger, clientFactory, jobTemplate)}},


### PR DESCRIPTION
### what
Concourse expires its ATC-Authorization cookie in 24 hours after login.
It's too short and frustrate me.
So I added the `auth-expire` parameter.

### usage
With binary:
```
./concourse web --auth-expire 48h ...
```
format comes from [time.Duration](https://golang.org/pkg/time/#ParseDuration)(unfortunately time.Day does not exist).