### PR TITLE
Fix invalid response from /api/v1/cli when file not found

### DIFF
--- a/api/cliserver/download.go
+++ b/api/cliserver/download.go
@@ -2,6 +2,7 @@ package cliserver
 
 import (
 	"net/http"
+	"os"
 	"path/filepath"
 )
 
@@ -36,7 +37,13 @@ func (s *Server) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Disposition", "attachment; filename="+filename)
+	downloadFullPath := filepath.Join(s.cliDownloadsDir, platform, arch, "fly")
 
 	http.ServeFile(w, r, filepath.Join(s.cliDownloadsDir, "fly_"+platform+"_"+arch))
+	_, err := os.Stat(downloadFullPath)
+	if err == nil {
+		w.Header().Set("Content-Disposition", "attachment; filename="+filename)
+	}
+
+	http.ServeFile(w, r, downloadFullPath)
 }

--- a/api/cliserver/download.go
+++ b/api/cliserver/download.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"code.cloudfoundry.org/lager"
 )
 
 func (s *Server) Download(w http.ResponseWriter, r *http.Request) {
@@ -43,6 +45,8 @@ func (s *Server) Download(w http.ResponseWriter, r *http.Request) {
 	_, err := os.Stat(downloadFullPath)
 	if err == nil {
 		w.Header().Set("Content-Disposition", "attachment; filename="+filename)
+	} else {
+		s.logger.Error("failed-to-stat-file", err, lager.Data{"filepath": downloadFullPath})
 	}
 
 	http.ServeFile(w, r, downloadFullPath)


### PR DESCRIPTION
This was setting a header for the file attachment and when the file wasn't found, browsers would try to open the non-existent file and fail causing a 'something when wrong' page instead of a '404 missing' page.
