### PR TITLE
Implemention of scope verification for oauth authorization

### DIFF
--- a/api/teams_test.go
+++ b/api/teams_test.go
@@ -133,6 +133,7 @@ var _ = Describe("Teams API", func() {
 								ClientSecret:  "don't tell anyone",
 								AuthURL:       "https://auth.url",
 								AuthURLParams: map[string]string{"allow_humans": "false"},
+								Scope:         "readonly",
 								TokenURL:      "https://token.url",
 							},
 						},
@@ -566,6 +567,7 @@ var _ = Describe("Teams API", func() {
 							AuthURLParams: map[string]string{"key": "value"},
 							TokenURL:      "https://goa.token.url",
 							DisplayName:   "CSI",
+							Scope:         "readonly",
 						}
 					})
 
@@ -651,6 +653,7 @@ var _ = Describe("Teams API", func() {
 								Expect(genericOAuth.AuthURL).To(Equal(team.GenericOAuth.AuthURL))
 								Expect(genericOAuth.TokenURL).To(Equal(team.GenericOAuth.TokenURL))
 								Expect(genericOAuth.AuthURLParams).To(Equal(team.GenericOAuth.AuthURLParams))
+								Expect(genericOAuth.Scope).To(Equal(team.GenericOAuth.Scope))
 								Expect(genericOAuth.DisplayName).To(Equal(team.GenericOAuth.DisplayName))
 
 								savedTeam.GenericOAuth = genericOAuth

--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -733,6 +733,7 @@ func (cmd *ATCCommand) configureAuthForDefaultTeam(teamDBFactory db.TeamDBFactor
 		genericOAuth = &db.GenericOAuth{
 			AuthURL:       cmd.GenericOAuth.AuthURL,
 			AuthURLParams: cmd.GenericOAuth.AuthURLParams,
+			Scope:         cmd.GenericOAuth.Scope,
 			TokenURL:      cmd.GenericOAuth.TokenURL,
 			ClientID:      cmd.GenericOAuth.ClientID,
 			ClientSecret:  cmd.GenericOAuth.ClientSecret,

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -28,8 +28,15 @@ func NewProvider(
 		endpoint.TokenURL = genericOAuth.TokenURL
 	}
 
+	var oauthVerifier verifier.Verifier
+	if genericOAuth.Scope != "" {
+		oauthVerifier = ScopeVerifier{scope: genericOAuth.Scope}
+	} else {
+		oauthVerifier = NoopVerifier{}
+	}
+
 	return Provider{
-		Verifier: NoopVerifier{},
+		Verifier: oauthVerifier,
 		Config: ConfigOverride{
 			Config: oauth2.Config{
 				ClientID:     genericOAuth.ClientID,

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -30,7 +30,7 @@ func NewProvider(
 
 	var oauthVerifier verifier.Verifier
 	if genericOAuth.Scope != "" {
-		oauthVerifier = ScopeVerifier{scope: genericOAuth.Scope}
+		oauthVerifier = NewScopeVerifier(genericOAuth.Scope)
 	} else {
 		oauthVerifier = NoopVerifier{}
 	}

--- a/auth/genericoauth/scope_verifier.go
+++ b/auth/genericoauth/scope_verifier.go
@@ -1,0 +1,75 @@
+package genericoauth
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/atc/auth/verifier"
+	"github.com/dgrijalva/jwt-go"
+)
+
+type ScopeVerifier struct {
+	scope string
+}
+
+func NewScopeVerifier(
+	scope string,
+) verifier.Verifier {
+	return ScopeVerifier{
+		scope: scope,
+	}
+}
+
+type GenericOAuthToken struct {
+	Scopes []string `json:"scope"`
+}
+
+func (verifier ScopeVerifier) Verify(logger lager.Logger, httpClient *http.Client) (bool, error) {
+	oauth2Transport, ok := httpClient.Transport.(*oauth2.Transport)
+	if !ok {
+		return false, errors.New("httpClient transport must be of type oauth2.Transport")
+	}
+
+	token, err := oauth2Transport.Source.Token()
+	if err != nil {
+		return false, err
+	}
+
+	tokenParts := strings.Split(token.AccessToken, ".")
+	if len(tokenParts) < 2 {
+		return false, errors.New("access token contains an invalid number of segments")
+	}
+
+	decodedClaims, err := jwt.DecodeSegment(tokenParts[1])
+	if err != nil {
+		return false, err
+	}
+
+	var oauthToken GenericOAuthToken
+	err = json.Unmarshal(decodedClaims, &oauthToken)
+	if err != nil {
+		return false, err
+	}
+
+	if len(oauthToken.Scopes) == 0 {
+		return false, errors.New("user has no assigned scopes in access token")
+	}
+
+	for _, userScope := range oauthToken.Scopes {
+		if userScope == verifier.scope {
+			return true, nil
+		}
+	}
+
+	logger.Info("does-not-have-scope", lager.Data{
+		"have": oauthToken.Scopes,
+		"want": verifier.scope,
+	})
+
+	return false, nil
+}

--- a/auth/genericoauth/scope_verifier_test.go
+++ b/auth/genericoauth/scope_verifier_test.go
@@ -1,0 +1,102 @@
+package genericoauth_test
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"code.cloudfoundry.org/lager/lagertest"
+	. "github.com/concourse/atc/auth/genericoauth"
+	"github.com/concourse/atc/auth/verifier"
+	"github.com/dgrijalva/jwt-go"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ScopeVerifier", func() {
+	var verifier verifier.Verifier
+	var httpClient *http.Client
+	var verified bool
+	var verifyErr error
+	var jwtToken *jwt.Token
+
+	BeforeEach(func() {
+
+		verifier = NewScopeVerifier(
+			"mainteam",
+		)
+
+		jwtToken = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"exp": time.Now().Add(time.Hour * 72).Unix(),
+		})
+
+		accessToken, err := jwtToken.SigningString()
+		Expect(err).NotTo(HaveOccurred())
+
+		oauthToken := &oauth2.Token{
+			AccessToken: accessToken,
+		}
+		c := &oauth2.Config{}
+		httpClient = c.Client(oauth2.NoContext, oauthToken)
+	})
+
+	JustBeforeEach(func() {
+		verified, verifyErr = verifier.Verify(lagertest.NewTestLogger("test"), httpClient)
+	})
+
+	Context("when token does not contain 'scope'", func() {
+		It("user is not verified", func() {
+			Expect(verified).To(BeFalse())
+			Expect(verifyErr).To(HaveOccurred())
+		})
+	})
+
+	Context("when user has proper scope", func() {
+		BeforeEach(func() {
+			jwtToken = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"exp":   time.Now().Add(time.Hour * 72).Unix(),
+				"scope": []string{"read", "write", "mainteam"},
+			})
+
+			accessToken, err := jwtToken.SigningString()
+			Expect(err).NotTo(HaveOccurred())
+
+			oauthToken := &oauth2.Token{
+				AccessToken: accessToken,
+			}
+			c := &oauth2.Config{}
+			httpClient = c.Client(oauth2.NoContext, oauthToken)
+		})
+
+		It("returns true", func() {
+			Expect(verifyErr).NotTo(HaveOccurred())
+			Expect(verified).To(BeTrue())
+		})
+
+	})
+
+	Context("and user does not have proper scope", func() {
+		BeforeEach(func() {
+			jwtToken = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"exp":   time.Now().Add(time.Hour * 72).Unix(),
+				"scope": []string{"read"},
+			})
+
+			accessToken, err := jwtToken.SigningString()
+			Expect(err).NotTo(HaveOccurred())
+
+			oauthToken := &oauth2.Token{
+				AccessToken: accessToken,
+			}
+			c := &oauth2.Config{}
+			httpClient = c.Client(oauth2.NoContext, oauthToken)
+		})
+
+		It("returns false", func() {
+			Expect(verifyErr).NotTo(HaveOccurred())
+			Expect(verified).To(BeFalse())
+		})
+	})
+})

--- a/auth_flags.go
+++ b/auth_flags.go
@@ -74,6 +74,7 @@ type GenericOAuthFlag struct {
 	ClientSecret  string            `long:"client-secret"  description:"Application client secret for enabling generic OAuth."`
 	AuthURL       string            `long:"auth-url"       description:"Generic OAuth provider AuthURL endpoint."`
 	AuthURLParams map[string]string `long:"auth-url-param" description:"Parameter to pass to the authentication server AuthURL. Can be specified multiple times."`
+	Scope         string            `long:"scope"          description:"Optional scope required to authorize user"`
 	TokenURL      string            `long:"token-url"      description:"Generic OAuth provider TokenURL endpoint."`
 }
 

--- a/db/db_teams_test.go
+++ b/db/db_teams_test.go
@@ -107,6 +107,7 @@ var _ = Describe("SQL DB Teams", func() {
 					ClientSecret:  "don't tell anyone",
 					AuthURL:       "https://auth.url",
 					AuthURLParams: map[string]string{"allow_humans": "false"},
+					Scope:         "readonly",
 				},
 			}
 			savedTeam4, err := database.CreateTeam(team4)
@@ -273,6 +274,7 @@ var _ = Describe("SQL DB Teams", func() {
 					ClientSecret:  "don't tell anyone",
 					AuthURL:       "https://auth.url",
 					AuthURLParams: map[string]string{"allow_humans": "false"},
+					Scope:         "readonly",
 				},
 			}
 			expectedSavedTeam, err := database.CreateTeam(expectedTeam)

--- a/db/team.go
+++ b/db/team.go
@@ -80,4 +80,5 @@ type GenericOAuth struct {
 	ClientID      string            `json:"client_id"`
 	ClientSecret  string            `json:"client_secret"`
 	DisplayName   string            `json:"display_name"`
+	Scope         string            `json:"scope"`
 }

--- a/db/team_db_test.go
+++ b/db/team_db_test.go
@@ -311,6 +311,7 @@ var _ = Describe("TeamDB", func() {
 				ClientSecret:  "don't tell anyone",
 				AuthURL:       "https://auth.url",
 				AuthURLParams: map[string]string{"option": "1"},
+				Scope:         "read",
 				TokenURL:      "https://token.url",
 			}
 		})

--- a/team.go
+++ b/team.go
@@ -52,4 +52,5 @@ type GenericOAuth struct {
 	AuthURL       string            `json:"auth_url,omitempty"`
 	TokenURL      string            `json:"token_url,omitempty"`
 	AuthURLParams map[string]string `json:"auth_url_params,omitempty"`
+	Scope         string            `json:"scope,omitempty"`
 }


### PR DESCRIPTION
This adds an optional way to require a particular scope for authorization of a user when using the generic oauth provider. 