### PR TITLE
Treat workers with tag "default" as if they had no tags.

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -684,7 +684,7 @@ func (worker *gardenWorker) Uptime() time.Duration {
 
 func (worker *gardenWorker) tagsMatch(tags []string) bool {
 	if len(worker.tags) > 0 && len(tags) == 0 {
-		return false
+		tags = []string{"default"}
 	}
 
 insert_coin:

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -2033,11 +2033,26 @@ var _ = Describe("Worker", func() {
 					spec.Tags = nil
 				})
 
-				It("returns ErrIncompatiblePlatform", func() {
-					Expect(satisfyingErr).To(Equal(ErrMismatchedTags))
+				Context("when the worker does not have the \"default\" tag", func() {
+					It("returns ErrIncompatiblePlatform", func() {
+						Expect(satisfyingErr).To(Equal(ErrMismatchedTags))
+					})
+				})
+
+				Context("when the worker has the \"default\" tag", func() {
+					BeforeEach(func() {
+						tags = []string{"some", "tags", "default"}
+					})
+
+					It("returns the worker", func() {
+						Expect(satisfyingWorker).To(Equal(gardenWorker))
+					})
+
+					It("returns no error", func() {
+						Expect(satisfyingErr).NotTo(HaveOccurred())
+					})
 				})
 			})
-
 			Context("when the worker has no tags", func() {
 				BeforeEach(func() {
 					tags = []string{}


### PR DESCRIPTION
Sometimes we want to tag our workers, but still want them to be part of the
default pool. In this case the tags can be considered as merely conveying
additional information.
