### PR TITLE
Expose new environment variable BUILD_TEAM_NAME

### DIFF
--- a/engine/exec_engine.go
+++ b/engine/exec_engine.go
@@ -154,6 +154,7 @@ func buildMetadata(build db.Build, externalURL string) StepMetadata {
 		BuildName:    build.Name(),
 		JobName:      build.JobName(),
 		PipelineName: build.PipelineName(),
+		TeamName:     build.TeamName(),
 		ExternalURL:  externalURL,
 	}
 }

--- a/engine/exec_engine_hooks_test.go
+++ b/engine/exec_engine_hooks_test.go
@@ -51,12 +51,14 @@ var _ = Describe("Exec Engine With Hooks", func() {
 		build.NameReturns("42")
 		build.JobNameReturns("some-job")
 		build.PipelineNameReturns("some-pipeline")
+		build.TeamNameReturns("some-team")
 
 		expectedMetadata = engine.StepMetadata{
 			BuildID:      84,
 			BuildName:    "42",
 			JobName:      "some-job",
 			PipelineName: "some-pipeline",
+			TeamName:     "some-team",
 			ExternalURL:  "http://example.com",
 		}
 	})

--- a/engine/exec_engine_test.go
+++ b/engine/exec_engine_test.go
@@ -95,6 +95,7 @@ var _ = Describe("ExecEngine", func() {
 				BuildName:    "21",
 				JobName:      "some-job",
 				PipelineName: "some-pipeline",
+				TeamName:     "some-team",
 				ExternalURL:  "http://example.com",
 			}
 
@@ -1121,6 +1122,7 @@ var _ = Describe("ExecEngine", func() {
 					BuildName:    "21",
 					JobName:      "some-job",
 					PipelineName: "some-pipeline",
+					TeamName:     "some-team",
 					ExternalURL:  "http://example.com",
 				}))
 				Expect(workerMetadata).To(Equal(worker.Metadata{

--- a/engine/exec_engine_try_test.go
+++ b/engine/exec_engine_try_test.go
@@ -52,12 +52,14 @@ var _ = Describe("Exec Engine with Try", func() {
 		build.NameReturns("42")
 		build.JobNameReturns("some-job")
 		build.PipelineNameReturns("some-pipeline")
+		build.TeamNameReturns("main")
 
 		expectedMetadata = engine.StepMetadata{
 			BuildID:      84,
 			BuildName:    "42",
 			JobName:      "some-job",
 			PipelineName: "some-pipeline",
+			TeamName:     "main",
 			ExternalURL:  "http://example.com",
 		}
 	})

--- a/engine/step_metadata.go
+++ b/engine/step_metadata.go
@@ -9,6 +9,7 @@ type StepMetadata struct {
 	JobName      string
 	BuildName    string
 	ExternalURL  string
+	TeamName     string
 }
 
 func (metadata StepMetadata) Env() []string {
@@ -28,6 +29,10 @@ func (metadata StepMetadata) Env() []string {
 
 	if metadata.ExternalURL != "" {
 		env = append(env, "ATC_EXTERNAL_URL="+metadata.ExternalURL)
+	}
+
+	if metadata.TeamName != "" {
+		env = append(env, "BUILD_TEAM_NAME="+metadata.TeamName)
 	}
 
 	return env

--- a/engine/step_metadata_test.go
+++ b/engine/step_metadata_test.go
@@ -16,12 +16,14 @@ var _ = Describe("StepMetadata", func() {
 				JobName:      "some-job-name",
 				BuildName:    "42",
 				ExternalURL:  "http://www.example.com",
+				TeamName:     "some-team",
 			}.Env()).To(Equal([]string{
 				"BUILD_ID=1",
 				"BUILD_PIPELINE_NAME=some-pipeline-name",
 				"BUILD_JOB_NAME=some-job-name",
 				"BUILD_NAME=42",
 				"ATC_EXTERNAL_URL=http://www.example.com",
+				"BUILD_TEAM_NAME=some-team",
 			}))
 		})
 


### PR DESCRIPTION
This exposes the new environment variable `BUILD_TEAM_NAME`, so you can people where to find their logs.