### PR TITLE
Use team.slug for GitHub auth teams matching

### DIFF
--- a/auth/github/client.go
+++ b/auth/github/client.go
@@ -62,7 +62,9 @@ func (c *client) Teams(httpClient *http.Client) (OrganizationTeams, error) {
 				organizationTeams[organizationName] = []string{}
 			}
 
+			// We add both forms (slug and name) of team
 			organizationTeams[organizationName] = append(organizationTeams[organizationName], *team.Name)
+			organizationTeams[organizationName] = append(organizationTeams[organizationName], *team.Slug)
 		}
 
 		nextPage = resp.NextPage

--- a/auth/github/client_test.go
+++ b/auth/github/client_test.go
@@ -176,8 +176,8 @@ var _ = Describe("Client", func() {
 				teams, err := client.Teams(proxiedClient)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(teams).To(HaveLen(2))
-				Expect(teams["org-1"]).To(ConsistOf([]string{"Team 1", "Team 2"}))
-				Expect(teams["org-2"]).To(ConsistOf([]string{"Team 3"}))
+				Expect(teams["org-1"]).To(ConsistOf([]string{"Team 1", "team-1", "Team 2", "team-2"}))
+				Expect(teams["org-2"]).To(ConsistOf([]string{"Team 3", "team-3"}))
 			})
 		})
 
@@ -267,8 +267,8 @@ var _ = Describe("Client", func() {
 				teams, err := client.Teams(proxiedClient)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(teams).To(HaveLen(2))
-				Expect(teams["org-1"]).To(ConsistOf([]string{"Team 1", "Team 2"}))
-				Expect(teams["org-2"]).To(ConsistOf([]string{"Team 3"}))
+				Expect(teams["org-1"]).To(ConsistOf([]string{"Team 1", "team-1", "Team 2", "team-2"}))
+				Expect(teams["org-2"]).To(ConsistOf([]string{"Team 3", "team-3"}))
 			})
 		})
 


### PR DESCRIPTION
Currently Concourse is using `team.name` returned by GitHub's API for matching teams, this is causing issues when team name contain special characters, as these are encoded.

For example if you want to auth against team named `Monkeys & Bananas` under organization `myorg`, team has to be passed to Concourse as `myorg/Monkeys \u0026 Bananas`, else it's not matched.

GitHub teams API returns also `team.slug`, which is machine friendly version (also used in GitHub's urls) and would look like `monkeys-bananas` (see https://developer.github.com/v3/orgs/teams/#list-user-teams). I would suggest using this preferably to the name.

*Please note that this is potentially breaking change for current configuration.*