### PR TITLE
Set cookie headers.

### DIFF
--- a/api/api_suite_test.go
+++ b/api/api_suite_test.go
@@ -65,6 +65,8 @@ var (
 	peerAddr                      string
 	drain                         chan struct{}
 	expire                        time.Duration
+	httpOnly                      bool
+	secure                        bool
 	cliDownloadsDir               string
 	logger                        *lagertest.TestLogger
 
@@ -137,6 +139,8 @@ var _ = BeforeEach(func() {
 	logger.RegisterSink(sink)
 
 	expire = 24 * time.Hour
+	httpOnly = true
+	secure = false
 
 	build = new(dbfakes.FakeBuild)
 
@@ -191,6 +195,8 @@ var _ = BeforeEach(func() {
 		sink,
 
 		expire,
+		httpOnly,
+		secure,
 
 		cliDownloadsDir,
 		"1.2.3",

--- a/api/authserver/get_auth_token.go
+++ b/api/authserver/get_auth_token.go
@@ -44,10 +44,12 @@ func (s *Server) GetAuthToken(w http.ResponseWriter, r *http.Request) {
 	token.Value = string(tokenValue)
 
 	http.SetCookie(w, &http.Cookie{
-		Name:    CookieName,
-		Value:   fmt.Sprintf("%s %s", token.Type, token.Value),
-		Path:    "/",
-		Expires: time.Now().Add(s.expire),
+		Name:     CookieName,
+		Value:    fmt.Sprintf("%s %s", token.Type, token.Value),
+		Path:     "/",
+		Expires:  time.Now().Add(s.expire),
+		HttpOnly: s.httpOnly,
+		Secure:   s.secure,
 	})
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api/authserver/server.go
+++ b/api/authserver/server.go
@@ -16,6 +16,8 @@ type Server struct {
 	providerFactory auth.ProviderFactory
 	teamDBFactory   db.TeamDBFactory
 	expire          time.Duration
+	httpOnly        bool
+	secure          bool
 }
 
 func NewServer(
@@ -26,6 +28,8 @@ func NewServer(
 	providerFactory auth.ProviderFactory,
 	teamDBFactory db.TeamDBFactory,
 	expire time.Duration,
+	httpOnly bool,
+	secure bool,
 ) *Server {
 	return &Server{
 		logger:          logger,
@@ -35,5 +39,7 @@ func NewServer(
 		providerFactory: providerFactory,
 		teamDBFactory:   teamDBFactory,
 		expire:          expire,
+		httpOnly:        httpOnly,
+		secure:          secure,
 	}
 }

--- a/api/handler.go
+++ b/api/handler.go
@@ -68,6 +68,8 @@ func NewHandler(
 	sink *lager.ReconfigurableSink,
 
 	expire time.Duration,
+	httpOnly bool,
+	secure bool,
 
 	cliDownloadsDir string,
 	version string,
@@ -89,6 +91,8 @@ func NewHandler(
 		providerFactory,
 		teamDBFactory,
 		expire,
+		httpOnly,
+		secure,
 	)
 
 	buildServer := buildserver.NewServer(

--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -69,6 +69,8 @@ type ATCCommand struct {
 	OAuthBaseURL URLFlag `long:"oauth-base-url" description:"URL used as the base of OAuth redirect URIs. If not specified, the external URL is used."`
 
 	AuthDuration time.Duration `long:"auth-duration" default:"24h" description:"Length of time for which tokens are valid. Afterwards, users will have to log back in."`
+	HttpOnly     bool          `default:"true" description:"Set HttpOnly flag on cookies"`
+	Secure       bool          `default:"false" description:"Set Secure flag on cookies"`
 
 	PostgresDataSource string `long:"postgres-data-source" default:"postgres://127.0.0.1:5432/atc?sslmode=disable" description:"PostgreSQL connection string."`
 
@@ -235,6 +237,8 @@ func (cmd *ATCCommand) Runner(args []string) (ifrit.Runner, error) {
 		teamDBFactory,
 		signingKey,
 		cmd.AuthDuration,
+		cmd.HttpOnly,
+		cmd.Secure,
 	)
 	if err != nil {
 		return nil, err
@@ -878,6 +882,8 @@ func (cmd *ATCCommand) constructAPIHandler(
 		reconfigurableSink,
 
 		cmd.AuthDuration,
+		cmd.HttpOnly,
+		cmd.Secure,
 
 		cmd.CLIArtifactsDir.Path(),
 		Version,

--- a/auth/logout_handler_test.go
+++ b/auth/logout_handler_test.go
@@ -27,6 +27,8 @@ var _ = Describe("LogOutHandler", func() {
 			response            *http.Response
 			err                 error
 			expire              time.Duration
+			httpOnly            bool
+			secure              bool
 		)
 
 		BeforeEach(func() {
@@ -35,6 +37,8 @@ var _ = Describe("LogOutHandler", func() {
 			signingKey, err = rsa.GenerateKey(rand.Reader, 1024)
 			Expect(err).ToNot(HaveOccurred())
 			expire = 24 * time.Hour
+			httpOnly = true
+			secure = false
 
 			handler, err := auth.NewOAuthHandler(
 				lagertest.NewTestLogger("test"),
@@ -42,6 +46,8 @@ var _ = Describe("LogOutHandler", func() {
 				fakeTeamDBFactory,
 				signingKey,
 				expire,
+				httpOnly,
+				secure,
 			)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/auth/oauth_begin_handler.go
+++ b/auth/oauth_begin_handler.go
@@ -26,6 +26,8 @@ type OAuthBeginHandler struct {
 	privateKey      *rsa.PrivateKey
 	teamDBFactory   db.TeamDBFactory
 	expire          time.Duration
+	httpOnly        bool
+	secure          bool
 }
 
 func NewOAuthBeginHandler(
@@ -34,6 +36,8 @@ func NewOAuthBeginHandler(
 	privateKey *rsa.PrivateKey,
 	teamDBFactory db.TeamDBFactory,
 	expire time.Duration,
+	httpOnly bool,
+	secure bool,
 ) http.Handler {
 	return &OAuthBeginHandler{
 		logger:          logger,
@@ -41,6 +45,8 @@ func NewOAuthBeginHandler(
 		privateKey:      privateKey,
 		teamDBFactory:   teamDBFactory,
 		expire:          expire,
+		httpOnly:        httpOnly,
+		secure:          secure,
 	}
 }
 
@@ -102,10 +108,12 @@ func (handler *OAuthBeginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	authCodeURL := provider.AuthCodeURL(encodedState)
 
 	http.SetCookie(w, &http.Cookie{
-		Name:    OAuthStateCookie,
-		Value:   encodedState,
-		Path:    "/",
-		Expires: time.Now().Add(handler.expire),
+		Name:     OAuthStateCookie,
+		Value:    encodedState,
+		Path:     "/",
+		Expires:  time.Now().Add(handler.expire),
+		HttpOnly: handler.httpOnly,
+		Secure:   handler.secure,
 	})
 
 	http.Redirect(w, r, authCodeURL, http.StatusTemporaryRedirect)

--- a/auth/oauth_begin_handler_test.go
+++ b/auth/oauth_begin_handler_test.go
@@ -36,7 +36,9 @@ var _ = Describe("OAuthBeginHandler", func() {
 
 		signingKey *rsa.PrivateKey
 
-		expire time.Duration
+		expire   time.Duration
+		httpOnly bool
+		secure   bool
 
 		cookieJar *cookiejar.Jar
 
@@ -55,6 +57,8 @@ var _ = Describe("OAuthBeginHandler", func() {
 		signingKey, err = rsa.GenerateKey(rand.Reader, 1024)
 		Expect(err).ToNot(HaveOccurred())
 		expire = 24 * time.Hour
+		httpOnly = true
+		secure = false
 
 		fakeTeamDBFactory = new(dbfakes.FakeTeamDBFactory)
 		fakeTeamDBFactory.GetTeamDBReturns(fakeTeamDB)
@@ -64,6 +68,8 @@ var _ = Describe("OAuthBeginHandler", func() {
 			fakeTeamDBFactory,
 			signingKey,
 			expire,
+			httpOnly,
+			secure,
 		)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/auth/oauth_callback_handler.go
+++ b/auth/oauth_callback_handler.go
@@ -23,6 +23,8 @@ type OAuthCallbackHandler struct {
 	tokenGenerator  TokenGenerator
 	teamDBFactory   db.TeamDBFactory
 	expire          time.Duration
+	httpOnly        bool
+	secure          bool
 }
 
 func NewOAuthCallbackHandler(
@@ -31,6 +33,8 @@ func NewOAuthCallbackHandler(
 	privateKey *rsa.PrivateKey,
 	teamDBFactory db.TeamDBFactory,
 	expire time.Duration,
+	httpOnly bool,
+	secure bool,
 ) http.Handler {
 	return &OAuthCallbackHandler{
 		logger:          logger,
@@ -39,6 +43,8 @@ func NewOAuthCallbackHandler(
 		tokenGenerator:  NewTokenGenerator(privateKey),
 		teamDBFactory:   teamDBFactory,
 		expire:          expire,
+		httpOnly:        httpOnly,
+		secure:          secure,
 	}
 }
 
@@ -170,10 +176,12 @@ func (handler *OAuthCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 	tokenStr := string(tokenType) + " " + string(signedToken)
 
 	http.SetCookie(w, &http.Cookie{
-		Name:    CookieName,
-		Value:   tokenStr,
-		Path:    "/",
-		Expires: exp,
+		Name:     CookieName,
+		Value:    tokenStr,
+		Path:     "/",
+		Expires:  exp,
+		HttpOnly: handler.httpOnly,
+		Secure:   handler.secure,
 	})
 
 	// Deletes the oauth state cookie to avoid CSRF attacks

--- a/auth/oauth_callback_handler_test.go
+++ b/auth/oauth_callback_handler_test.go
@@ -63,7 +63,9 @@ var _ = Describe("OAuthCallbackHandler", func() {
 
 		signingKey *rsa.PrivateKey
 
-		expire time.Duration
+		expire   time.Duration
+		httpOnly bool
+		secure   bool
 
 		server *httptest.Server
 		client *http.Client
@@ -80,6 +82,8 @@ var _ = Describe("OAuthCallbackHandler", func() {
 		signingKey, err = rsa.GenerateKey(rand.Reader, 1024)
 		Expect(err).ToNot(HaveOccurred())
 		expire = 24 * time.Hour
+		httpOnly = true
+		secure = false
 
 		fakeProviderFactory.GetProviderStub = func(team db.SavedTeam, providerName string) (provider.Provider, bool, error) {
 			if providerName == "some-provider" {
@@ -108,6 +112,8 @@ var _ = Describe("OAuthCallbackHandler", func() {
 			fakeTeamDBFactory,
 			signingKey,
 			expire,
+			httpOnly,
+			secure,
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -259,6 +265,8 @@ var _ = Describe("OAuthCallbackHandler", func() {
 							It("set to a signed token that expires in 1 day", func() {
 								Expect(cookie.Name).To(Equal(auth.CookieName))
 								Expect(cookie.Expires).To(BeTemporally("~", time.Now().Add(24*time.Hour), 5*time.Second))
+								Expect(cookie.HttpOnly).To(BeTrue())
+								Expect(cookie.Secure).To(BeFalse())
 
 								Expect(cookie.Value).To(MatchRegexp(`^Bearer .*`))
 

--- a/auth/oauth_handler.go
+++ b/auth/oauth_handler.go
@@ -26,6 +26,8 @@ func NewOAuthHandler(
 	teamDBFactory db.TeamDBFactory,
 	signingKey *rsa.PrivateKey,
 	expire time.Duration,
+	httpOnly bool,
+	secure bool,
 ) (http.Handler, error) {
 	return rata.NewRouter(
 		OAuthRoutes,
@@ -36,6 +38,8 @@ func NewOAuthHandler(
 				signingKey,
 				teamDBFactory,
 				expire,
+				httpOnly,
+				secure,
 			),
 			OAuthCallback: NewOAuthCallbackHandler(
 				logger.Session("oauth-callback"),
@@ -43,6 +47,8 @@ func NewOAuthHandler(
 				signingKey,
 				teamDBFactory,
 				expire,
+				httpOnly,
+				secure,
 			),
 			LogOut: NewLogOutHandler(
 				logger.Session("logout"),


### PR DESCRIPTION
Allow operators to set `HttpOnly` and `Secure` cookie headers for security / compliance purposes.