### PR TITLE
Added request method to http_response_time metric

### DIFF
--- a/metric/http.go
+++ b/metric/http.go
@@ -29,6 +29,7 @@ func (handler MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	HTTPResponseTime{
 		Route:    handler.Route,
 		Path:     r.URL.Path,
+		Method:   r.Method,
 		Duration: time.Since(start),
 	}.Emit(handler.Logger)
 }

--- a/metric/metrics.go
+++ b/metric/metrics.go
@@ -206,6 +206,7 @@ func ms(duration time.Duration) float64 {
 type HTTPResponseTime struct {
 	Route    string
 	Path     string
+	Method   string
 	Duration time.Duration
 }
 
@@ -231,8 +232,9 @@ func (event HTTPResponseTime) Emit(logger lager.Logger) {
 			Metric:  ms(event.Duration),
 			State:   state,
 			Attributes: map[string]string{
-				"route": event.Route,
-				"path":  event.Path,
+				"route":  event.Route,
+				"path":   event.Path,
+				"method": event.Method,
 			},
 		},
 	)


### PR DESCRIPTION
- Useful in case we want to filter PUTs, POSTs and GETS
- e.g. when I care about clicks on the UI versus (PUTs/POSTs) vs the UI
  just loading things (GETs)

Signed-off-by: Dan Wendorf <dwendorf@pivotal.io>