### PR TITLE
Fix failed-to-save-versions bug

### DIFF
--- a/db/migrations/45_add_unique_constraint_to_versioned_resources.go
+++ b/db/migrations/45_add_unique_constraint_to_versioned_resources.go
@@ -20,7 +20,7 @@ func AddUniqueConstraintToResources(tx migration.LimitedTx) error {
 
 	_, err = tx.Exec(`
 		CREATE UNIQUE INDEX versioned_resources_resource_id_type_version
-		ON versioned_resources (resource_id, type, version)
+		ON versioned_resources (resource_id, type, md5(version))
 	`)
 	if err != nil {
 		return err


### PR DESCRIPTION
Today I've encountered an issue when using https://github.com/vito/git-branch-heads-resource.

Apparently, once you get enough branches concourse fails to save the information in it's DB:
```
{"timestamp":"1482158328.343481541","source":"atc","message":"atc.syncer.app:scheduler.tick.scheduling.try-start-next-pending-build.scan.failed-to-save-versions","log_level":2,"data":{"build-id":383,"build-name":"139","error":"pq: inde
x row size 2760 exceeds maximum 2712 for index \"versioned_resources_resource_id_type_version\"","input":"branch-repo"
<snip!>
```

Narrowed it down to an internal postgresql limitation, in which a b-tree index cannot index rows larger than 2712 bytes. Since it's entirely possible to have a resource that returns versions larger than that (like the aforementioned git-branch-heads), I fixed that by replacing `version` with `md5(version)` in the index, preventing such problems in the future.

After getting confirmation from @pivotal-topher-bullock that this is worthy of a PR, I'm opening it ;) 