### PR TITLE
[WIP] Restrict privileged tasks to specific teams.

### DIFF
--- a/db/team.go
+++ b/db/team.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Team struct {
-	Name  string
-	Admin bool
+	Name            string
+	Admin           bool
+	AllowPrivileged bool
 
 	BasicAuth    *BasicAuth    `json:"basic_auth"`
 	GitHubAuth   *GitHubAuth   `json:"github_auth"`


### PR DESCRIPTION
From https://concourse.ci/teams.html:

> In the future, we'll probably have this as a flag on a team, indicating whether they're permitted to run privileged builds.

This is a (very) incomplete start on this work--submitting early to see whether you all are interested, and whether this is the right place to start. For this to be complete, would also need to update `db/team_db.go` and/or `dbng/team_factory.go` (not exactly sure of the difference between `db` and `dbng`), and prevent `set-pipeline` with privileged tasks in the first place. I'm hoping to get some feedback on this little attempt and then fix and flesh out.