### PR TITLE
gracefully scale the legend with browser zooming

### DIFF
--- a/web/assets/css/production.less
+++ b/web/assets/css/production.less
@@ -301,13 +301,13 @@ li.prep-status {
   dt {
     width: 10px;
     height: 10px;
-    margin: 4px;
+    margin: 5px;
     float: left;
   }
 
   dd {
     margin-left: 22px;
-    line-height: 18px;
+    line-height: 20px;
   }
 }
 


### PR DESCRIPTION
Fixes concourse/atc#153

Still has issues with 33% and 67% zoom, though those are unlikely use cases.