### PR TITLE
Fix VersionConfig.UnmarshalYAML

### DIFF
--- a/config.go
+++ b/config.go
@@ -261,12 +261,14 @@ func (c *VersionConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case string:
 		c.Every = actual == "every"
 		c.Latest = actual == "latest"
-	case map[string]interface{}:
+	case map[interface{}]interface{}:
 		version := Version{}
 
 		for k, v := range actual {
-			if s, ok := v.(string); ok {
-				version[k] = strings.TrimSpace(s)
+			if ks, ok := k.(string); ok {
+				if vs, ok := v.(string); ok {
+					version[ks] = strings.TrimSpace(vs)
+				}
 			}
 		}
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,10 @@
 package atc_test
 
 import (
+	"encoding/json"
+
 	. "github.com/concourse/atc"
+	yaml "gopkg.in/yaml.v2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -97,6 +100,42 @@ var _ = Describe("Config", func() {
 				}
 
 				Expect(jobConfig.GetSerialGroups()).To(Equal([]string{}))
+			})
+		})
+	})
+
+	Describe("VersionConfig", func() {
+		Context("when unmarshaling a pinned version from YAML", func() {
+			It("produces the correct version config without error", func() {
+				var versionConfig VersionConfig
+				bs := []byte(`some: version`)
+				err := yaml.Unmarshal(bs, &versionConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				expected := VersionConfig{
+					Pinned: Version{
+						"some": "version",
+					},
+				}
+
+				Expect(versionConfig).To(Equal(expected))
+			})
+		})
+
+		Context("when unmarshaling a pinned version from JSON", func() {
+			It("produces the correct version config without error", func() {
+				var versionConfig VersionConfig
+				bs := []byte(`{ "some": "version" }`)
+				err := json.Unmarshal(bs, &versionConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				expected := VersionConfig{
+					Pinned: Version{
+						"some": "version",
+					},
+				}
+
+				Expect(versionConfig).To(Equal(expected))
 			})
 		})
 	})


### PR DESCRIPTION
The YAML implementation here was derived from the JSON implementation, which is what is actually used everywhere. I know; I wrote both.

When actually trying to unmarshal some YAML with a pinned version it broke.

This fixes it!