### PR TITLE
Surface error when resource has invalid resource type [#139412087]

### DIFF
--- a/radar/resource_scanner.go
+++ b/radar/resource_scanner.go
@@ -275,6 +275,10 @@ func (scanner *resourceScanner) scan(
 	)
 	if err != nil {
 		logger.Error("failed-to-initialize-new-container", err)
+		setErr := scanner.db.SetResourceCheckError(savedResource, err)
+		if setErr != nil {
+			logger.Error("failed-to-set-check-error", err)
+		}
 		return err
 	}
 

--- a/radar/resource_scanner_test.go
+++ b/radar/resource_scanner_test.go
@@ -501,6 +501,21 @@ var _ = Describe("ResourceScanner", func() {
 				Expect(fakeLock.ReleaseCallCount()).To(Equal(1))
 			})
 
+			Context("when creating the resource checker fails", func() {
+				BeforeEach(func() {
+					fakeResourceFactory.NewCheckResourceReturns(fakeResource, errors.New("catastrophe"))
+				})
+
+				It("sets the check error and returns the error", func() {
+					Expect(scanErr).To(HaveOccurred())
+					Expect(fakeRadarDB.SetResourceCheckErrorCallCount()).To(Equal(1))
+
+					resourceName, resourceErr := fakeRadarDB.SetResourceCheckErrorArgsForCall(0)
+					Expect(resourceName).To(Equal(savedResource))
+					Expect(resourceErr).To(MatchError("catastrophe"))
+				})
+			})
+
 			Context("when the resource config has a specified check interval", func() {
 				BeforeEach(func() {
 					savedResource.Config.CheckEvery = "10ms"


### PR DESCRIPTION
This resolves https://github.com/concourse/concourse/issues/915 by displaying an error inside the resource page when the resource has an invalid type.