### PR TITLE
Firefox has a default left padding on ul

### DIFF
--- a/web/assets/css/layout.less
+++ b/web/assets/css/layout.less
@@ -205,6 +205,7 @@ pre {
   ul {
     list-style: none;
     margin: 0px;
+    padding: 0px;
   }
 
   .team {


### PR DESCRIPTION
Which makes the menu indented by about 15px.

I'd generally recommend using a CSS reset / normalize.css because firefox has a bunch of minor css glitches like these (I assume the site was designed in chrome)

Before
<img width="240" alt="screen shot 2017-04-05 at 17 42 47" src="https://cloud.githubusercontent.com/assets/1372918/24697229/57f7d204-1a27-11e7-9b85-16fa431abeb4.png">

After
<img width="236" alt="screen shot 2017-04-05 at 17 43 39" src="https://cloud.githubusercontent.com/assets/1372918/24697292/8ede685a-1a27-11e7-92c0-b711a41cd0a0.png">
