### PR TITLE
[WIP] Authorities for generic oauth client

### DIFF
--- a/auth/genericoauth/authority_verifier.go
+++ b/auth/genericoauth/authority_verifier.go
@@ -59,8 +59,8 @@ func (verifier AuthorityVerifier) Verify(logger lager.Logger, httpClient *http.C
 		return false, errors.New("user has no assigned authorities in access token")
 	}
 
-	for _, userScope := range oauthToken. {
-		if userScope == verifier.authority {
+	for _, userAuthority := range oauthToken.Authorities {
+		if userAuthority == verifier.authority {
 			return true, nil
 		}
 	}

--- a/auth/genericoauth/authority_verifier.go
+++ b/auth/genericoauth/authority_verifier.go
@@ -1,0 +1,74 @@
+package genericoauth
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/atc/auth/verifier"
+)
+
+type AuthorityVerifier struct {
+	authority string
+}
+
+func NewAuthorityVerifier(
+	authority string,
+) verifier.Verifier {
+	return AuthorityVerifier{
+		authority: authority,
+	}
+}
+
+type GenericOAuthToken struct {
+	Authorities []string `json:"authorities"`
+}
+
+func (verifier AuthorityVerifier) Verify(logger lager.Logger, httpClient *http.Client) (bool, error) {
+	oauth2Transport, ok := httpClient.Transport.(*oauth2.Transport)
+	if !ok {
+		return false, errors.New("httpClient transport must be of type oauth2.Transport")
+	}
+
+	token, err := oauth2Transport.Source.Token()
+	if err != nil {
+		return false, err
+	}
+
+	tokenParts := strings.Split(token.AccessToken, ".")
+	if len(tokenParts) < 2 {
+		return false, errors.New("access token contains an invalid number of segments")
+	}
+
+	decodedClaims, err := jwt.DecodeSegment(tokenParts[1])
+	if err != nil {
+		return false, err
+	}
+
+	var oauthToken GenericOAuthToken
+	err = json.Unmarshal(decodedClaims, &oauthToken)
+	if err != nil {
+		return false, err
+	}
+
+	if len(oauthToken.Authorities) == 0 {
+		return false, errors.New("user has no assigned authorities in access token")
+	}
+
+	for _, userScope := range oauthToken. {
+		if userScope == verifier.authority {
+			return true, nil
+		}
+	}
+
+	logger.Info("does-not-have-authority", lager.Data{
+		"have": oauthToken.Authorities,
+		"want": verifier.authority,
+	})
+
+	return false, nil
+}

--- a/auth/genericoauth/authority_verifier_test.go
+++ b/auth/genericoauth/authority_verifier_test.go
@@ -1,0 +1,101 @@
+package genericoauth_test
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"code.cloudfoundry.org/lager/lagertest"
+	. "github.com/concourse/atc/auth/genericoauth"
+	"github.com/concourse/atc/auth/verifier"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AuthorityVerifier", func() {
+	var verifier verifier.Verifier
+	var httpClient *http.Client
+	var verified bool
+	var verifyErr error
+	var jwtToken *jwt.Token
+
+	BeforeEach(func() {
+
+		verifier = NewAuthorityVerifier(
+			"mainteam",
+		)
+
+		jwtToken = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"exp": time.Now().Add(time.Hour * 72).Unix(),
+		})
+
+		accessToken, err := jwtToken.SigningString()
+		Expect(err).NotTo(HaveOccurred())
+
+		oauthToken := &oauth2.Token{
+			AccessToken: accessToken,
+		}
+		c := &oauth2.Config{}
+		httpClient = c.Client(oauth2.NoContext, oauthToken)
+	})
+
+	JustBeforeEach(func() {
+		verified, verifyErr = verifier.Verify(lagertest.NewTestLogger("test"), httpClient)
+	})
+
+	Context("when token does not contain 'authorities'", func() {
+		It("user is not verified", func() {
+			Expect(verified).To(BeFalse())
+			Expect(verifyErr).To(HaveOccurred())
+		})
+	})
+
+	Context("when user has proper authority", func() {
+		BeforeEach(func() {
+			jwtToken = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"exp":       time.Now().Add(time.Hour * 72).Unix(),
+				"authority": []string{"mainteam"},
+			})
+
+			accessToken, err := jwtToken.SigningString()
+			Expect(err).NotTo(HaveOccurred())
+
+			oauthToken := &oauth2.Token{
+				AccessToken: accessToken,
+			}
+			c := &oauth2.Config{}
+			httpClient = c.Client(oauth2.NoContext, oauthToken)
+		})
+
+		It("returns true", func() {
+			Expect(verifyErr).NotTo(HaveOccurred())
+			Expect(verified).To(BeTrue())
+		})
+
+	})
+
+	Context("and user does not have proper authority", func() {
+		BeforeEach(func() {
+			jwtToken = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"exp":       time.Now().Add(time.Hour * 72).Unix(),
+				"authority": []string{"someotherteam"},
+			})
+
+			accessToken, err := jwtToken.SigningString()
+			Expect(err).NotTo(HaveOccurred())
+
+			oauthToken := &oauth2.Token{
+				AccessToken: accessToken,
+			}
+			c := &oauth2.Config{}
+			httpClient = c.Client(oauth2.NoContext, oauthToken)
+		})
+
+		It("returns false", func() {
+			Expect(verifyErr).NotTo(HaveOccurred())
+			Expect(verified).To(BeFalse())
+		})
+	})
+})

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -45,6 +45,7 @@ type GenericOAuthConfig struct {
 	AuthURL       string            `json:"auth_url,omitempty"          long:"auth-url"        description:"Generic OAuth provider AuthURL endpoint."`
 	AuthURLParams map[string]string `json:"auth_url_params,omitempty"   long:"auth-url-param"  description:"Parameter to pass to the authentication server AuthURL. Can be specified multiple times."`
 	Scope         string            `json:"scope,omitempty"             long:"scope"           description:"Optional scope required to authorize user"`
+	Authority     string            `json:"authorities,omitempty"       long:"authorities"     description:"Optional authority required to authorize user"`
 	TokenURL      string            `json:"token_url,omitempty"         long:"token-url"       description:"Generic OAuth provider TokenURL endpoint."`
 }
 
@@ -141,9 +142,12 @@ func (GenericTeamProvider) ProviderConstructor(
 	}
 
 	var oauthVerifier verifier.Verifier
-	if genericOAuth.Scope != "" {
+	if genericOAuth.Scope != "" && genericOAuth.Authority = "" {
 		oauthVerifier = NewScopeVerifier(genericOAuth.Scope)
-	} else {
+	} else if genericOAuth.Scope = "" && genericOAuth.Authority != "" {
+		oauthVerifier = NewAuthorityVerifier(genericOAuth.Authority)
+	}
+	else {
 		oauthVerifier = NoopVerifier{}
 	}
 


### PR DESCRIPTION
I'm entirely new to Go so there's probably lot's more needed that I'm not aware of, but this seemed like a decent enough first start. Please note that I'd be happy to get support from others on this PR! :smile: 

This basically attempts to add basic initial support for a `--generic-oauth-authority <authority name>` argument to fly's `set-team` command.

Related to my feature request: concourse/concourse#1026