### PR TITLE
Use anchor tags (<a>) for clickable elements

### DIFF
--- a/web/assets/css/layout.less
+++ b/web/assets/css/layout.less
@@ -256,15 +256,15 @@ pre {
           background: @base00;
           display: flex;
 
-          span {
+          .btn-pause {
             flex-grow: 0;
+
+            i {
+                padding: 8px 0;
+            }
           }
 
-          i {
-            padding: 8px 0;
-          }
-
-          a {
+          .pipeline {
             padding: 8px 0;
 
             flex-grow: 1;

--- a/web/assets/css/retry.less
+++ b/web/assets/css/retry.less
@@ -10,7 +10,7 @@
     cursor: pointer;
     color: @base06;
 
-    span {
+    a {
       padding: 0 5px;
       display: inline-block;
     }

--- a/web/elm/src/SideBar.elm
+++ b/web/elm/src/SideBar.elm
@@ -608,7 +608,8 @@ viewDraggable maybeDragInfo uip =
         [ Html.div []
             [ viewPauseButton uip
             , Html.a
-                [ onLeftClick <| NavToPipeline uip.pipeline.url
+                [ class "pipeline"
+                , onLeftClick <| NavToPipeline uip.pipeline.url
                 , href uip.pipeline.url
                 ]
                 [ Html.text uip.pipeline.name ]
@@ -646,7 +647,7 @@ viewDropArea teamName pipelineName =
 viewPauseButton : UIPipeline -> Html Msg
 viewPauseButton uip =
     if uip.pipeline.paused then
-        Html.span
+        Html.a
             [ Events.onClick <| UnpausePipeline uip.pipeline.teamName uip.pipeline.name
             , class <|
                 if uip.pauseErrored then
@@ -660,7 +661,7 @@ viewPauseButton uip =
             else
                 [ Html.i [ class "fa fa-fw fa-play" ] [] ]
     else
-        Html.span
+        Html.a
             [ Events.onClick <| PausePipeline uip.pipeline.teamName uip.pipeline.name
             , class <|
                 if uip.pauseErrored then

--- a/web/elm/src/StepTree.elm
+++ b/web/elm/src/StepTree.elm
@@ -579,7 +579,7 @@ viewTab id currentTab idx step =
     in
         Html.li
             [ classList [ ( "current", currentTab == tab ), ( "inactive", not <| treeIsActive step ) ] ]
-            [ Html.span [ onClick (SwitchTab id tab) ] [ Html.text (toString tab) ] ]
+            [ Html.a [ onClick (SwitchTab id tab) ] [ Html.text (toString tab) ] ]
 
 
 viewSeq : Model -> StepTree -> Html Msg


### PR DESCRIPTION
I use a Chrome Extension called [Vimium](https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=en) to navigate most websites, however I cannot use it to click Concourse's retry tabs and pipeline pause/unpause buttons because they are based on `<span>` tags instead of `<a>` tags (so they're not recognized as being clickable elements, despite the associated `onClick` event handlers).

Anyway, I have to resort to reaching for a mouse, which makes me sad.