### PR TITLE
Added custom paths to use github personal access token for the authen…

### DIFF
--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -1,23 +1,20 @@
 package genericoauth
 
 import (
+	"code.cloudfoundry.org/lager"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
-
-	"code.cloudfoundry.org/lager"
-
-	"encoding/json"
-
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/auth/provider"
 	"github.com/concourse/atc/auth/routes"
 	"github.com/concourse/atc/auth/verifier"
 	"github.com/hashicorp/go-multierror"
-	flags "github.com/jessevdk/go-flags"
+	"github.com/jessevdk/go-flags"
 	"github.com/tedsuo/rata"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
+	"net/http"
 )
 
 const ProviderName = "oauth"

--- a/auth/github/provider.go
+++ b/auth/github/provider.go
@@ -1,24 +1,20 @@
 package github
 
 import (
-	"errors"
-	"net/http"
-
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/github"
-
-	"fmt"
-	"strings"
-
 	"encoding/json"
-
+	"errors"
+	"fmt"
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/auth/provider"
 	"github.com/concourse/atc/auth/routes"
 	"github.com/concourse/atc/auth/verifier"
 	"github.com/hashicorp/go-multierror"
-	flags "github.com/jessevdk/go-flags"
+	"github.com/jessevdk/go-flags"
 	"github.com/tedsuo/rata"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/github"
+	"net/http"
+	"strings"
 )
 
 const ProviderName = "github"

--- a/auth/gitlab/provider.go
+++ b/auth/gitlab/provider.go
@@ -15,7 +15,7 @@ import (
 	"github.com/concourse/atc/auth/routes"
 	"github.com/concourse/atc/auth/verifier"
 	"github.com/hashicorp/go-multierror"
-	flags "github.com/jessevdk/go-flags"
+	"github.com/jessevdk/go-flags"
 	"github.com/tedsuo/rata"
 )
 

--- a/auth/oauth_handler.go
+++ b/auth/oauth_handler.go
@@ -1,16 +1,15 @@
 package auth
 
 import (
-	"crypto/rsa"
-	"net/http"
-	"time"
-
 	"code.cloudfoundry.org/lager"
+	"crypto/rsa"
 	"github.com/concourse/atc/auth/provider"
 	"github.com/concourse/atc/auth/routes"
 	"github.com/concourse/atc/db"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/tedsuo/rata"
+	"net/http"
+	"time"
 )
 
 var SigningMethod = jwt.SigningMethodRS256
@@ -50,6 +49,13 @@ func NewOAuthHandler(
 			),
 			routes.LogOut: NewLogOutHandler(
 				logger.Session("logout"),
+			),
+			routes.Token: NewTokenHandler(
+				logger.Session("token"),
+				providerFactory,
+				signingKey,
+				teamFactory,
+				expire,
 			),
 		},
 	)

--- a/auth/provider/provider.go
+++ b/auth/provider/provider.go
@@ -1,17 +1,13 @@
 package provider
 
 import (
-	"net/http"
-
-	"github.com/concourse/atc"
-	flags "github.com/jessevdk/go-flags"
-
 	"code.cloudfoundry.org/lager"
-
 	"encoding/json"
-
+	"github.com/concourse/atc"
+	"github.com/jessevdk/go-flags"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
+	"net/http"
 )
 
 //go:generate counterfeiter . Provider

--- a/auth/provider/providerfakes/fake_team_provider.go
+++ b/auth/provider/providerfakes/fake_team_provider.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/concourse/atc/auth/provider"
-	"github.com/jessevdk/go-flags"
+	flags "github.com/jessevdk/go-flags"
 )
 
 type FakeTeamProvider struct {

--- a/auth/routes/oauth_routes.go
+++ b/auth/routes/oauth_routes.go
@@ -6,10 +6,12 @@ const (
 	OAuthBegin    = "OAuthBegin"
 	OAuthCallback = "OAuthCallback"
 	LogOut        = "LogOut"
+	Token         = "Token"
 )
 
 var OAuthRoutes = rata.Routes{
 	{Path: "/auth/logout", Method: "GET", Name: LogOut},
 	{Path: "/auth/:provider/callback", Method: "GET", Name: OAuthCallback},
 	{Path: "/auth/:provider", Method: "GET", Name: OAuthBegin},
+	{Path: "/auth/:provider/token", Method: "POST", Name: Token},
 }

--- a/auth/token_handler.go
+++ b/auth/token_handler.go
@@ -1,0 +1,138 @@
+package auth
+
+import (
+	"bytes"
+	"code.cloudfoundry.org/lager"
+	"context"
+	"crypto/rsa"
+	"github.com/concourse/atc/db"
+	"golang.org/x/oauth2"
+	"io"
+	"net/http"
+	"time"
+)
+
+type TokenHandler struct {
+	logger             lager.Logger
+	authTokenGenerator AuthTokenGenerator
+	expire             time.Duration
+	csrfTokenGenerator CSRFTokenGenerator
+	teamFactory        db.TeamFactory
+	providerFactory    ProviderFactory
+}
+
+func NewTokenHandler(
+	logger lager.Logger,
+	providerFactory ProviderFactory,
+	privateKey *rsa.PrivateKey,
+	teamFactory db.TeamFactory,
+	expire time.Duration,
+) http.Handler {
+	return &TokenHandler{
+		logger:             logger,
+		authTokenGenerator: NewAuthTokenGenerator(privateKey),
+		expire:             expire,
+		csrfTokenGenerator: NewCSRFTokenGenerator(),
+		teamFactory:        teamFactory,
+		providerFactory:    providerFactory,
+	}
+}
+
+func (handler *TokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	hLog := handler.logger.Session("token")
+	providerName := r.FormValue(":provider")
+	teamName := r.FormValue("team_name")
+
+	token := StreamToString(r.Body)
+
+	if token == "" {
+		handler.logger.Info("failed-to-find-token-in-body")
+		http.Error(w, "Token is not present in body", http.StatusBadRequest)
+		return
+	}
+
+	team, found, err := handler.teamFactory.FindTeam(teamName)
+
+	if err != nil {
+		hLog.Error("failed-to-get-team", err, lager.Data{
+			"teamName": teamName,
+			"provider": providerName,
+		})
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if !found {
+		hLog.Info("failed-to-find-team", lager.Data{
+			"teamName": teamName,
+		})
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	provider, found, err := handler.providerFactory.GetProvider(team, providerName)
+	if err != nil {
+		handler.logger.Error("failed-to-get-provider", err, lager.Data{
+			"provider": providerName,
+			"teamName": teamName,
+		})
+
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !found {
+		handler.logger.Info("team-does-not-have-auth-provider", lager.Data{
+			"provider": providerName,
+		})
+
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	// crete new client that supports a token authentication
+	ctx := context.Background()
+
+	tc := provider.Client(ctx, &oauth2.Token{AccessToken: token})
+
+	verified, err := provider.Verify(handler.logger, tc)
+	if err != nil {
+		handler.logger.Error("error-while-verifying-user", err)
+		http.Error(w, "error durring verification", http.StatusInternalServerError)
+		return
+	}
+	if !verified {
+		handler.logger.Info("failed-to-verify-user", lager.Data{
+			"teamName": teamName,
+		})
+		http.Error(w, "not verified", http.StatusUnauthorized)
+		return
+	}
+
+	// generate token
+	exp := time.Now().Add(handler.expire)
+
+	csrfToken, err := handler.csrfTokenGenerator.GenerateToken()
+	if err != nil {
+		handler.logger.Error("generate-csrf-token", err)
+		http.Error(w, "failed to generate csrf token", http.StatusInternalServerError)
+		return
+	}
+
+	tokenType, signedToken, err := handler.authTokenGenerator.GenerateToken(exp, team.Name(), team.Admin(), csrfToken)
+	if err != nil {
+		handler.logger.Error("failed-to-sign-token", err)
+		http.Error(w, "failed to generate auth token", http.StatusInternalServerError)
+		return
+	}
+
+	tokenStr := string(tokenType) + " " + string(signedToken)
+
+	io.WriteString(w, tokenStr)
+}
+
+func StreamToString(stream io.Reader) string {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(stream)
+	return buf.String()
+}

--- a/auth/token_handler_test.go
+++ b/auth/token_handler_test.go
@@ -1,0 +1,176 @@
+package auth_test
+
+import (
+	"code.cloudfoundry.org/lager/lagertest"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"github.com/concourse/atc"
+	"github.com/concourse/atc/auth"
+	"github.com/concourse/atc/auth/authfakes"
+	"github.com/concourse/atc/auth/provider/providerfakes"
+	"github.com/concourse/atc/db/dbfakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"time"
+)
+
+var _ = Describe("TokenHandler", func() {
+	var (
+		fakeProvider *providerfakes.FakeProvider
+
+		fakeProviderFactory *authfakes.FakeProviderFactory
+
+		fakeTeamFactory *dbfakes.FakeTeamFactory
+		fakeTeam        *dbfakes.FakeTeam
+
+		signingKey *rsa.PrivateKey
+
+		expire time.Duration
+
+		server *httptest.Server
+		client *http.Client
+
+		request  *http.Request
+		response *http.Response
+	)
+
+	BeforeEach(func() {
+
+		fakeProvider = new(providerfakes.FakeProvider)
+		fakeProviderFactory = new(authfakes.FakeProviderFactory)
+
+		fakeTeam = new(dbfakes.FakeTeam)
+		fakeTeamFactory = new(dbfakes.FakeTeamFactory)
+
+		var err error
+		signingKey, err = rsa.GenerateKey(rand.Reader, 1024)
+		Expect(err).ToNot(HaveOccurred())
+		expire = 24 * time.Hour
+
+		handler, err := auth.NewOAuthHandler(
+			lagertest.NewTestLogger("test"),
+			fakeProviderFactory,
+			fakeTeamFactory,
+			signingKey,
+			expire,
+			false,
+		)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		server = httptest.NewServer(handler)
+
+		fakeProviderFactory.GetProviderReturns(fakeProvider, true, nil)
+
+		request, err = http.NewRequest("POST", server.URL, strings.NewReader("some-token"))
+
+		Expect(err).NotTo(HaveOccurred())
+
+		request.URL.Path = "/auth/some-provider/token"
+
+		request.URL.RawQuery = url.Values{
+			"team_name": {"some-team"},
+		}.Encode()
+
+		client = &http.Client{
+			Transport: &http.Transport{},
+		}
+	})
+
+	JustBeforeEach(func() {
+		var err error
+
+		response, err = client.Do(request)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("POST /auth/some-provider/token", func() {
+
+		Context("A token is present", func() {
+			BeforeEach(func() {
+				fakeTeam.NameReturns("some-team")
+				fakeTeam.BasicAuthReturns(&atc.BasicAuth{BasicAuthUsername: "some-username"})
+				fakeTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+			})
+
+			Context("and the user is verified", func() {
+
+				BeforeEach(func() {
+					fakeProvider.VerifyReturns(true, nil)
+				})
+
+				It("returns a valid token", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+					Expect(ioutil.ReadAll(response.Body)).To(HavePrefix("Bearer "))
+				})
+			})
+
+			Context("and the user is not verified", func() {
+
+				BeforeEach(func() {
+					fakeProvider.VerifyReturns(false, nil)
+				})
+
+				It("returns a correct error response", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+					Expect(ioutil.ReadAll(response.Body)).ToNot(HavePrefix("Bearer "))
+				})
+			})
+
+			Context("and the user can not be verified", func() {
+
+				BeforeEach(func() {
+					fakeProvider.VerifyReturns(false, errors.New("Exception"))
+				})
+
+				It("returns a correct error response", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+				})
+			})
+
+			Context("and the team can not be found", func() {
+
+				BeforeEach(func() {
+					fakeProvider.VerifyReturns(true, nil)
+					fakeTeamFactory.FindTeamReturns(nil, false, nil)
+				})
+
+				It("returns a correct error response", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+				})
+			})
+
+			Context("and the team can not be found due to an error", func() {
+
+				BeforeEach(func() {
+					fakeProvider.VerifyReturns(true, nil)
+					fakeTeamFactory.FindTeamReturns(nil, false, errors.New("Exception"))
+				})
+
+				It("returns a correct error response", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+				})
+			})
+		})
+
+		Context("A token is not present", func() {
+			BeforeEach(func() {
+				fakeTeam.NameReturns("some-team")
+				fakeTeam.BasicAuthReturns(&atc.BasicAuth{BasicAuthUsername: "some-username"})
+				fakeTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+				request.Body = nil
+				request.ContentLength = 0
+			})
+
+			It("returns a correct error response", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+			})
+		})
+	})
+})

--- a/auth/uaa/provider.go
+++ b/auth/uaa/provider.go
@@ -3,23 +3,21 @@ package uaa
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"path/filepath"
-	"strings"
-
-	"encoding/json"
-
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/auth/provider"
 	"github.com/concourse/atc/auth/routes"
 	"github.com/concourse/atc/auth/verifier"
 	"github.com/hashicorp/go-multierror"
-	flags "github.com/jessevdk/go-flags"
+	"github.com/jessevdk/go-flags"
 	"github.com/tedsuo/rata"
 	"golang.org/x/oauth2"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"strings"
 )
 
 const ProviderName = "uaa"


### PR DESCRIPTION
…tication

The following things have been changed:

* Add the possibility for providers to add custom endpoints. The `github` provider adds a `/token` endpoint with `POST`
* Pass the logger to all providers to enable creating custom routes.
* Create a new `TokenHandler` for the `GithubbProvider` that can read personal access tokens from the body of a `POST` requests and checks if the user is allowed to access the given team.
* Do the normal authorization and authentication flow that is used for all other methods. I just had to create a different `http.Client` to use with github.

This is just the first part for the `ATC` to support `Personal Accesss Tokens`. 
After the review and potential merge I would enhance the `fly` commandline tool to retreive a token for the `login` command.

This is my first contribution in go, so please go ahead and point out all mistakes and possible bad practies. This one is a `DRAFT` atm.

@vito FYI

I need to delay the Signment of the CLA until my employee Adobe has granted me the right to do so, so please see this as a point of discussion atm.

Edit: Signing the CLA will take approximately 6 weeks.