### PR TITLE
Convert type to string so that it can be converted by library

### DIFF
--- a/db/build.go
+++ b/db/build.go
@@ -365,7 +365,7 @@ func (b *build) Delete() (bool, error) {
 
 func (b *build) Abort() error {
 	_, err := psql.Update("builds").
-		Set("status", BuildStatusAborted).
+		Set("status", string(BuildStatusAborted)).
 		Where(sq.Eq{"id": b.id}).
 		RunWith(b.conn).
 		Exec()


### PR DESCRIPTION
I saw some messages in the ATC log like this:
```
{
  "timestamp": "1496628557.047648191",
  "source": "atc",
  "message": "atc.build-tracker.track.failed-to-lookup-started-builds",
  "log_level": 2,
  "data": {
    "error": "sql: converting Exec argument #0's type: unsupported type db.BuildStatus, a string",
    "session": "17.4"
  }
}
```

And I saw an example query here https://github.com/concourse/atc/blob/master/db/build.go#L259 where it is converting the type to a string. So I have made the same change to the Abort function, which stops this error from happening.