### PR TITLE
When many groups are created the page rendering is strange

### DIFF
--- a/web/assets/css/layout.less
+++ b/web/assets/css/layout.less
@@ -31,7 +31,8 @@ html, body, #elm-app-embed, #subpage, .content-frame {
       flex-shrink: 0;
       overflow-x: scroll;
       overflow-y: hidden;
-      width: 85%;
+      position: fixed;
+      right: 120px;
 
       li {
         flex-shrink: 0;

--- a/web/assets/css/layout.less
+++ b/web/assets/css/layout.less
@@ -40,6 +40,19 @@ html, body, #elm-app-embed, #subpage, .content-frame {
       }
     }
 
+    .groups::-webkit-scrollbar-track {
+      background-color: #1A252F;
+    }
+
+    .groups::-webkit-scrollbar {
+      height: 4px;
+      background-color: #1A252F;
+    }
+
+    .groups::-webkit-scrollbar-thumb {
+      background-color: #E6E7E8;
+    }
+
     .nav-right {
       flex-shrink: 1;
       position: fixed;

--- a/web/assets/css/layout.less
+++ b/web/assets/css/layout.less
@@ -38,19 +38,19 @@ html, body, #elm-app-embed, #subpage, .content-frame {
       li {
         flex-shrink: 0;
       }
-    }
 
-    .groups::-webkit-scrollbar-track {
-      background-color: #1A252F;
-    }
+      ::-webkit-scrollbar-track {
+        background-color: #1A252F;
+      }
 
-    .groups::-webkit-scrollbar {
-      height: 4px;
-      background-color: #1A252F;
-    }
+      ::-webkit-scrollbar {
+        height: 4px;
+        background-color: #1A252F;
+      }
 
-    .groups::-webkit-scrollbar-thumb {
-      background-color: #E6E7E8;
+      ::-webkit-scrollbar-thumb {
+        background-color: #E6E7E8;
+      }
     }
 
     .nav-right {

--- a/web/assets/css/layout.less
+++ b/web/assets/css/layout.less
@@ -25,13 +25,23 @@ html, body, #elm-app-embed, #subpage, .content-frame {
     height: @top-bar-height;
 
     .groups {
-      flex-grow: 1;
+      flex-grow: 0;
       display: flex;
       flex-direction: row;
+      flex-shrink: 0;
+      overflow-x: scroll;
+      overflow-y: hidden;
+      width: 85%;
+
+      li {
+        flex-shrink: 0;
+      }
     }
 
     .nav-right {
       flex-shrink: 1;
+      position: fixed;
+      right: 0;
 
       .user-info {
         text-align: right;

--- a/web/assets/css/layout.less
+++ b/web/assets/css/layout.less
@@ -33,6 +33,7 @@ html, body, #elm-app-embed, #subpage, .content-frame {
       overflow-y: hidden;
       position: fixed;
       right: 120px;
+      left: 0;
 
       li {
         flex-shrink: 0;

--- a/web/assets/css/layout.less
+++ b/web/assets/css/layout.less
@@ -29,7 +29,7 @@ html, body, #elm-app-embed, #subpage, .content-frame {
       display: flex;
       flex-direction: row;
       flex-shrink: 0;
-      overflow-x: scroll;
+      overflow-x: auto;
       overflow-y: hidden;
       position: fixed;
       right: 120px;


### PR DESCRIPTION
### What is it?

When displaying a large number of groups with names that combine to be wider than the page, group names are split over multiple lines and do not render right at all.

This PR is to make the navbar horizontally scrollable while pinning the user menu to the top right at all times.

Re-raising this due to CLA