### PR TITLE
Skip builds from paused jobs when getting next pending.

### DIFF
--- a/db/job.go
+++ b/db/job.go
@@ -340,6 +340,7 @@ func (j *job) GetNextPendingBuildBySerialGroup(serialGroups []string) (Build, bo
 		INNER JOIN jobs_serial_groups jsg ON j.id = jsg.job_id
 				AND jsg.serial_group IN (`+strings.Join(refs, ",")+`)
 		WHERE b.status = 'pending'
+			AND j.paused = false
 			AND j.inputs_determined = true
 			AND j.pipeline_id = $1
 		ORDER BY b.id ASC

--- a/db/job_test.go
+++ b/db/job_test.go
@@ -520,6 +520,17 @@ var _ = Describe("Job", func() {
 			Expect(found).To(BeTrue())
 			Expect(build.ID()).To(Equal(buildOne.ID()))
 
+			err = job1.Pause()
+			Expect(err).NotTo(HaveOccurred())
+
+			build, found, err = job1.GetNextPendingBuildBySerialGroup([]string{"serial-group"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(build.ID()).To(Equal(buildThree.ID()))
+
+			err = job1.Unpause()
+			Expect(err).NotTo(HaveOccurred())
+
 			build, found, err = job2.GetNextPendingBuildBySerialGroup([]string{"serial-group", "really-different-group"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())


### PR DESCRIPTION
At the moment, `Job.GetNextPendingBuild` doesn't check whether the build it gets is part of a pending job or not. That means that pending builds of paused jobs block builds of other jobs in the same serial group, as described in https://github.com/concourse/concourse/issues/520. This patch ignores builds of pending jobs in this method.

cc @cnelson 