### PR TITLE
abort button and build button html

### DIFF
--- a/web/elm/src/Build.elm
+++ b/web/elm/src/Build.elm
@@ -653,7 +653,7 @@ viewBuildHeader build { now, job, history } =
                                 Just job ->
                                     job.disableManualTrigger
                     in
-                        Html.button
+                        Html.span
                             [ class "build-action fr"
                             , disabled buttonDisabled
                             , attribute "aria-label" "Trigger Build"
@@ -668,7 +668,11 @@ viewBuildHeader build { now, job, history } =
         abortButton =
             if Concourse.BuildStatus.isRunning build.status then
                 Html.span
-                    [ class "build-action build-action-abort fr", onLeftClick (AbortBuild build.id), attribute "aria-label" "Abort Build" ]
+                    [ class "build-action build-action-abort fr"
+                    , onLeftClick (AbortBuild build.id)
+                    , attribute "aria-label" "Abort Build" 
+                    , attribute "title" "Abort Build"
+                    ]
                     [ Html.i [ class "fa fa-times-circle" ] [] ]
             else
                 Html.span [] []


### PR DESCRIPTION
* The "Trigger Build" button had different HTML than the "Abort Build" button. Now there is the same visual feedback when hovering over the two buttons.
* The "Abort Build" button was missing the "title" tag. 

