### PR TITLE
[Bug fix] Filter resource versions by type.

### DIFF
--- a/db/pipeline_test.go
+++ b/db/pipeline_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Pipeline", func() {
 					versions = append(versions, version)
 					expectedVersions = append(expectedVersions,
 						db.SavedVersionedResource{
-							ID:      i + 1,
+							ID:      i + 2,
 							Enabled: true,
 							VersionedResource: db.VersionedResource{
 								Resource: resource.Name,
@@ -312,7 +312,19 @@ var _ = Describe("Pipeline", func() {
 						})
 				}
 
-				err := pipeline.SaveResourceVersions(resource, versions)
+				err := pipeline.SaveResourceVersions(
+					atc.ResourceConfig{
+						Name:   "some-resource",
+						Type:   "another-type",
+						Source: atc.Source{"some": "source"},
+					},
+					[]atc.Version{
+						{"version": "0"},
+					},
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = pipeline.SaveResourceVersions(resource, versions)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -404,7 +416,7 @@ var _ = Describe("Pipeline", func() {
 
 			Context("when a version is disabled", func() {
 				BeforeEach(func() {
-					pipeline.DisableVersionedResource(10)
+					pipeline.DisableVersionedResource(11)
 
 					expectedVersions[9].Enabled = false
 				})


### PR DESCRIPTION
If the type of a resource changes, resource versions from the previous
resource type can be fetched and passed to builds. This leads to
unexpected build errors, since resource version metadata from one
resource type may not be usable to another resource type. This commit
filters resource versions by the current type of the resource.

cc @chendrix 