### PR TITLE
Make baggageclaim response header timeout configurable

### DIFF
--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -101,10 +101,10 @@ type ATCCommand struct {
 
 	SessionSigningKey FileFlag `long:"session-signing-key" description:"File containing an RSA private key, used to sign session tokens."`
 
-	ResourceCheckingInterval     time.Duration `long:"resource-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources."`
-	OldResourceGracePeriod       time.Duration `long:"old-resource-grace-period" default:"5m" description:"How long to cache the result of a get step after a newer version of the resource is found."`
-	ResourceCacheCleanupInterval time.Duration `long:"resource-cache-cleanup-interval" default:"30s" description:"Interval on which to cleanup old caches of resources."`
-	GardenResponseHeaderTimeout  time.Duration `long:"garden-response-header-timeout" default:"10m" description:"How long to wait for Garden to send the response header."`
+	ResourceCheckingInterval          time.Duration `long:"resource-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources."`
+	OldResourceGracePeriod            time.Duration `long:"old-resource-grace-period" default:"5m" description:"How long to cache the result of a get step after a newer version of the resource is found."`
+	ResourceCacheCleanupInterval      time.Duration `long:"resource-cache-cleanup-interval" default:"30s" description:"Interval on which to cleanup old caches of resources."`
+	BaggageclaimResponseHeaderTimeout time.Duration `long:"baggageclaim-response-header-timeout" default:"10m" description:"How long to wait for Baggageclaim to send the response header."`
 
 	CLIArtifactsDir DirFlag `long:"cli-artifacts-dir" description:"Directory containing downloadable CLI binaries."`
 
@@ -301,7 +301,7 @@ func (cmd *ATCCommand) Runner(args []string) (ifrit.Runner, error) {
 		dbWorkerFactory,
 		teamFactory,
 		workerVersion,
-		cmd.GardenResponseHeaderTimeout,
+		cmd.BaggageclaimResponseHeaderTimeout,
 	)
 
 	resourceFetcher := resourceFetcherFactory.FetcherFor(workerClient)
@@ -754,7 +754,7 @@ func (cmd *ATCCommand) constructWorkerPool(
 	dbWorkerFactory db.WorkerFactory,
 	teamFactory db.TeamFactory,
 	workerVersion *version.Version,
-	gardenResponseHeaderTimeout time.Duration,
+	baggageclaimResponseHeaderTimeout time.Duration,
 ) worker.Client {
 	imageResourceFetcherFactory := image.NewImageResourceFetcherFactory(
 		resourceFetcherFactory,
@@ -776,7 +776,7 @@ func (cmd *ATCCommand) constructWorkerPool(
 			teamFactory,
 			dbWorkerFactory,
 			workerVersion,
-			gardenResponseHeaderTimeout,
+			baggageclaimResponseHeaderTimeout,
 		),
 	)
 }

--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -104,6 +104,7 @@ type ATCCommand struct {
 	ResourceCheckingInterval     time.Duration `long:"resource-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources."`
 	OldResourceGracePeriod       time.Duration `long:"old-resource-grace-period" default:"5m" description:"How long to cache the result of a get step after a newer version of the resource is found."`
 	ResourceCacheCleanupInterval time.Duration `long:"resource-cache-cleanup-interval" default:"30s" description:"Interval on which to cleanup old caches of resources."`
+	GardenResponseHeaderTimeout  time.Duration `long:"garden-response-header-timeout" default:"10m" description:"How long to wait for Garden to send the response header."`
 
 	CLIArtifactsDir DirFlag `long:"cli-artifacts-dir" description:"Directory containing downloadable CLI binaries."`
 
@@ -300,6 +301,7 @@ func (cmd *ATCCommand) Runner(args []string) (ifrit.Runner, error) {
 		dbWorkerFactory,
 		teamFactory,
 		workerVersion,
+		cmd.GardenResponseHeaderTimeout,
 	)
 
 	resourceFetcher := resourceFetcherFactory.FetcherFor(workerClient)
@@ -752,6 +754,7 @@ func (cmd *ATCCommand) constructWorkerPool(
 	dbWorkerFactory db.WorkerFactory,
 	teamFactory db.TeamFactory,
 	workerVersion *version.Version,
+	gardenResponseHeaderTimeout time.Duration,
 ) worker.Client {
 	imageResourceFetcherFactory := image.NewImageResourceFetcherFactory(
 		resourceFetcherFactory,
@@ -773,6 +776,7 @@ func (cmd *ATCCommand) constructWorkerPool(
 			teamFactory,
 			dbWorkerFactory,
 			workerVersion,
+			gardenResponseHeaderTimeout,
 		),
 	)
 }

--- a/worker/db_worker_provider.go
+++ b/worker/db_worker_provider.go
@@ -31,6 +31,7 @@ type dbWorkerProvider struct {
 	dbTeamFactory                   db.TeamFactory
 	dbWorkerFactory                 db.WorkerFactory
 	workerVersion                   *version.Version
+	gardenResponseHeaderTimeout     time.Duration
 }
 
 func NewDBWorkerProvider(
@@ -45,6 +46,7 @@ func NewDBWorkerProvider(
 	dbTeamFactory db.TeamFactory,
 	workerFactory db.WorkerFactory,
 	workerVersion *version.Version,
+	gardenResponseHeaderTimeout time.Duration,
 ) WorkerProvider {
 	return &dbWorkerProvider{
 		lockFactory:                     lockFactory,
@@ -58,6 +60,7 @@ func NewDBWorkerProvider(
 		dbTeamFactory:                   dbTeamFactory,
 		dbWorkerFactory:                 workerFactory,
 		workerVersion:                   workerVersion,
+		gardenResponseHeaderTimeout:     gardenResponseHeaderTimeout,
 	}
 }
 
@@ -153,7 +156,7 @@ func (provider *dbWorkerProvider) newGardenWorker(logger lager.Logger, tikTok cl
 		provider.dbWorkerFactory,
 		&http.Transport{
 			DisableKeepAlives:     true,
-			ResponseHeaderTimeout: 10 * time.Minute,
+			ResponseHeaderTimeout: provider.gardenResponseHeaderTimeout,
 		},
 	))
 

--- a/worker/db_worker_provider.go
+++ b/worker/db_worker_provider.go
@@ -20,18 +20,18 @@ import (
 var ErrDesiredWorkerNotRunning = errors.New("desired garden worker is not known to be running")
 
 type dbWorkerProvider struct {
-	lockFactory                     lock.LockFactory
-	retryBackOffFactory             retryhttp.BackOffFactory
-	imageFactory                    ImageFactory
-	dbResourceCacheFactory          db.ResourceCacheFactory
-	dbResourceConfigFactory         db.ResourceConfigFactory
-	dbWorkerBaseResourceTypeFactory db.WorkerBaseResourceTypeFactory
-	dbWorkerTaskCacheFactory        db.WorkerTaskCacheFactory
-	dbVolumeFactory                 db.VolumeFactory
-	dbTeamFactory                   db.TeamFactory
-	dbWorkerFactory                 db.WorkerFactory
-	workerVersion                   *version.Version
-	gardenResponseHeaderTimeout     time.Duration
+	lockFactory                       lock.LockFactory
+	retryBackOffFactory               retryhttp.BackOffFactory
+	imageFactory                      ImageFactory
+	dbResourceCacheFactory            db.ResourceCacheFactory
+	dbResourceConfigFactory           db.ResourceConfigFactory
+	dbWorkerBaseResourceTypeFactory   db.WorkerBaseResourceTypeFactory
+	dbWorkerTaskCacheFactory          db.WorkerTaskCacheFactory
+	dbVolumeFactory                   db.VolumeFactory
+	dbTeamFactory                     db.TeamFactory
+	dbWorkerFactory                   db.WorkerFactory
+	workerVersion                     *version.Version
+	baggageclaimResponseHeaderTimeout time.Duration
 }
 
 func NewDBWorkerProvider(
@@ -46,21 +46,21 @@ func NewDBWorkerProvider(
 	dbTeamFactory db.TeamFactory,
 	workerFactory db.WorkerFactory,
 	workerVersion *version.Version,
-	gardenResponseHeaderTimeout time.Duration,
+	baggageclaimResponseHeaderTimeout time.Duration,
 ) WorkerProvider {
 	return &dbWorkerProvider{
-		lockFactory:                     lockFactory,
-		retryBackOffFactory:             retryBackOffFactory,
-		imageFactory:                    imageFactory,
-		dbResourceCacheFactory:          dbResourceCacheFactory,
-		dbResourceConfigFactory:         dbResourceConfigFactory,
-		dbWorkerBaseResourceTypeFactory: dbWorkerBaseResourceTypeFactory,
-		dbWorkerTaskCacheFactory:        dbWorkerTaskCacheFactory,
-		dbVolumeFactory:                 dbVolumeFactory,
-		dbTeamFactory:                   dbTeamFactory,
-		dbWorkerFactory:                 workerFactory,
-		workerVersion:                   workerVersion,
-		gardenResponseHeaderTimeout:     gardenResponseHeaderTimeout,
+		lockFactory:                       lockFactory,
+		retryBackOffFactory:               retryBackOffFactory,
+		imageFactory:                      imageFactory,
+		dbResourceCacheFactory:            dbResourceCacheFactory,
+		dbResourceConfigFactory:           dbResourceConfigFactory,
+		dbWorkerBaseResourceTypeFactory:   dbWorkerBaseResourceTypeFactory,
+		dbWorkerTaskCacheFactory:          dbWorkerTaskCacheFactory,
+		dbVolumeFactory:                   dbVolumeFactory,
+		dbTeamFactory:                     dbTeamFactory,
+		dbWorkerFactory:                   workerFactory,
+		workerVersion:                     workerVersion,
+		baggageclaimResponseHeaderTimeout: baggageclaimResponseHeaderTimeout,
 	}
 }
 
@@ -156,7 +156,7 @@ func (provider *dbWorkerProvider) newGardenWorker(logger lager.Logger, tikTok cl
 		provider.dbWorkerFactory,
 		&http.Transport{
 			DisableKeepAlives:     true,
-			ResponseHeaderTimeout: provider.gardenResponseHeaderTimeout,
+			ResponseHeaderTimeout: provider.baggageclaimResponseHeaderTimeout,
 		},
 	))
 

--- a/worker/db_worker_provider_test.go
+++ b/worker/db_worker_provider_test.go
@@ -31,14 +31,14 @@ var _ = Describe("DBProvider", func() {
 
 		logger *lagertest.TestLogger
 
-		fakeGardenBackend           *gfakes.FakeBackend
-		gardenAddr                  string
-		baggageclaimURL             string
-		wantWorkerVersion           version.Version
-		baggageclaimServer          *ghttp.Server
-		gardenServer                *server.GardenServer
-		provider                    WorkerProvider
-		gardenResponseHeaderTimeout time.Duration
+		fakeGardenBackend                 *gfakes.FakeBackend
+		gardenAddr                        string
+		baggageclaimURL                   string
+		wantWorkerVersion                 version.Version
+		baggageclaimServer                *ghttp.Server
+		gardenServer                      *server.GardenServer
+		provider                          WorkerProvider
+		baggageclaimResponseHeaderTimeout time.Duration
 
 		fakeImageFactory                    *workerfakes.FakeImageFactory
 		fakeImageFetchingDelegate           *workerfakes.FakeImageFetchingDelegate
@@ -85,7 +85,7 @@ var _ = Describe("DBProvider", func() {
 		fakeGardenBackend = new(gfakes.FakeBackend)
 		logger = lagertest.NewTestLogger("test")
 		gardenServer = server.New("tcp", gardenAddr, 0, fakeGardenBackend, logger)
-		gardenResponseHeaderTimeout = 10 * time.Minute
+		baggageclaimResponseHeaderTimeout = 10 * time.Minute
 		err := gardenServer.Start()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -154,7 +154,7 @@ var _ = Describe("DBProvider", func() {
 			fakeDBTeamFactory,
 			fakeDBWorkerFactory,
 			&wantWorkerVersion,
-			gardenResponseHeaderTimeout,
+			baggageclaimResponseHeaderTimeout,
 		)
 		baggageclaimURL = baggageclaimServer.URL()
 	})

--- a/worker/db_worker_provider_test.go
+++ b/worker/db_worker_provider_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+	"time"
 )
 
 var _ = Describe("DBProvider", func() {
@@ -30,13 +31,14 @@ var _ = Describe("DBProvider", func() {
 
 		logger *lagertest.TestLogger
 
-		fakeGardenBackend  *gfakes.FakeBackend
-		gardenAddr         string
-		baggageclaimURL    string
-		wantWorkerVersion  version.Version
-		baggageclaimServer *ghttp.Server
-		gardenServer       *server.GardenServer
-		provider           WorkerProvider
+		fakeGardenBackend           *gfakes.FakeBackend
+		gardenAddr                  string
+		baggageclaimURL             string
+		wantWorkerVersion           version.Version
+		baggageclaimServer          *ghttp.Server
+		gardenServer                *server.GardenServer
+		provider                    WorkerProvider
+		gardenResponseHeaderTimeout time.Duration
 
 		fakeImageFactory                    *workerfakes.FakeImageFactory
 		fakeImageFetchingDelegate           *workerfakes.FakeImageFetchingDelegate
@@ -83,6 +85,7 @@ var _ = Describe("DBProvider", func() {
 		fakeGardenBackend = new(gfakes.FakeBackend)
 		logger = lagertest.NewTestLogger("test")
 		gardenServer = server.New("tcp", gardenAddr, 0, fakeGardenBackend, logger)
+		gardenResponseHeaderTimeout = 10 * time.Minute
 		err := gardenServer.Start()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -151,6 +154,7 @@ var _ = Describe("DBProvider", func() {
 			fakeDBTeamFactory,
 			fakeDBWorkerFactory,
 			&wantWorkerVersion,
+			gardenResponseHeaderTimeout,
 		)
 		baggageclaimURL = baggageclaimServer.URL()
 	})


### PR DESCRIPTION
Work around for concourse/concourse#1333. This pull request makes the response header timeout for the Baggageclaim client in the Garden worker configurable, since even the generous ten minutes it is currently set to aren't enough sometimes. 