### PR TITLE
Present auth config to admin users on listing teams.

### DIFF
--- a/api/present/team.go
+++ b/api/present/team.go
@@ -11,3 +11,12 @@ func Team(team db.Team) atc.Team {
 		Name: team.Name(),
 	}
 }
+
+func TeamWithAdmin(team db.Team) atc.Team {
+	return atc.Team{
+		ID:        team.ID(),
+		Name:      team.Name(),
+		BasicAuth: team.BasicAuth(),
+		Auth:      team.Auth(),
+	}
+}

--- a/api/teams_test.go
+++ b/api/teams_test.go
@@ -113,6 +113,65 @@ var _ = Describe("Teams API", func() {
 					}
 				]`))
 			})
+			Context("when authenticated as non-admin team", func() {
+				BeforeEach(func() {
+					jwtValidator.IsAuthenticatedReturns(true)
+					userContextReader.GetTeamReturns("fake-team", false, true)
+				})
+				It("returns the teams with auth configuration", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(body).To(MatchJSON(`[
+						{
+							"id": 5,
+							"name": "avengers"
+						},
+						{
+							"id": 9,
+							"name": "aliens"
+						},
+						{
+							"id": 22,
+							"name": "predators"
+						}
+					]`))
+				})
+			})
+			Context("when authenticated as admin team", func() {
+				BeforeEach(func() {
+					jwtValidator.IsAuthenticatedReturns(true)
+					userContextReader.GetTeamReturns(atc.DefaultTeamName, true, true)
+				})
+				It("returns the teams with auth configuration", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(body).To(MatchJSON(`[
+						{
+							"id": 5,
+							"name": "avengers"
+						},
+						{
+							"id": 9,
+							"name": "aliens",
+							"basic_auth": {
+								"basic_auth_username": "fake user",
+								"basic_auth_password": "no, bad"
+							}
+						},
+						{
+							"id": 22,
+							"name": "predators",
+							"auth": {
+								"fake-provider": {
+									"hello": "world"
+								}
+							}
+						}
+					]`))
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
Based on chat with @chendrix around https://concourseci.slack.com/archives/C07RY25QF/p1499885468923378. The idea is for `ListTeams` to behave differently depending on the current user's access, like `ListPipelines`: it shows redacted teams if the user is not authenticated or authenticated to a non-admin team, and shows non-redacted teams if the user is authenticated to the admin team.

cc @cnelson 