### PR TITLE
Finalised token implementation for the login

### DIFF
--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -169,6 +169,7 @@ var _ = Describe("Auth API", func() {
 					Type:        atc.AuthTypeOAuth,
 					DisplayName: "fake display",
 					AuthURL:     "https://example.com/some-auth-url",
+					TokenURL:    "https://example.com/some-auth-url/token",
 				})
 
 				var err error
@@ -203,12 +204,14 @@ var _ = Describe("Auth API", func() {
 					{
 						"type": "oauth",
 						"display_name": "fake display",
-						"auth_url": "https://example.com/some-auth-url"
+						"auth_url": "https://example.com/some-auth-url",
+						"token_url": "https://example.com/some-auth-url/token"
 					},
 					{
 						"type": "basic",
 						"display_name": "Basic Auth",
-						"auth_url": "https://example.com/teams/some-team/login"
+						"auth_url": "https://example.com/teams/some-team/login",
+						"token_url": ""
 					}
 				]`))
 			})

--- a/auth.go
+++ b/auth.go
@@ -12,6 +12,7 @@ type AuthMethod struct {
 
 	DisplayName string `json:"display_name"`
 	AuthURL     string `json:"auth_url"`
+	TokenURL    string `json:"token_url"`
 }
 
 type AuthToken struct {

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -47,7 +47,7 @@ type GenericOAuthConfig struct {
 }
 
 func (config *GenericOAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.AuthMethod {
-	path, err := routes.OAuthRoutes.CreatePathForRoute(
+	oauthBegin, err := routes.OAuthRoutes.CreatePathForRoute(
 		routes.OAuthBegin,
 		rata.Params{"provider": ProviderName},
 	)
@@ -55,12 +55,22 @@ func (config *GenericOAuthConfig) AuthMethod(oauthBaseURL string, teamName strin
 		panic("failed to construct oauth begin handler route: " + err.Error())
 	}
 
-	path = path + fmt.Sprintf("?team_name=%s", teamName)
+	tokenLogin, err := routes.OAuthRoutes.CreatePathForRoute(
+		routes.Token,
+		rata.Params{"provider": ProviderName},
+	)
+	if err != nil {
+		panic("failed to construct token login handler route: " + err.Error())
+	}
+
+	oauthBegin = oauthBegin + fmt.Sprintf("?team_name=%s", teamName)
+	tokenLogin = tokenLogin + fmt.Sprintf("?team_name=%s", teamName)
 
 	return atc.AuthMethod{
 		Type:        atc.AuthTypeOAuth,
 		DisplayName: config.DisplayName,
-		AuthURL:     oauthBaseURL + path,
+		AuthURL:     oauthBaseURL + oauthBegin,
+		TokenURL:    oauthBaseURL + tokenLogin,
 	}
 }
 

--- a/auth/genericoauth/provider_test.go
+++ b/auth/genericoauth/provider_test.go
@@ -112,6 +112,7 @@ var _ = Describe("Generic OAuth Provider", func() {
 				Type:        atc.AuthTypeOAuth,
 				DisplayName: "duck-song",
 				AuthURL:     "http://bum-bum-bum.com/auth/oauth?team_name=dudududum",
+				TokenURL:    "http://bum-bum-bum.com/auth/oauth/token?team_name=dudududum",
 			}))
 		})
 	})

--- a/auth/github/provider.go
+++ b/auth/github/provider.go
@@ -35,7 +35,7 @@ type GitHubAuthConfig struct {
 }
 
 func (*GitHubAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.AuthMethod {
-	path, err := routes.OAuthRoutes.CreatePathForRoute(
+	oauthBegin, err := routes.OAuthRoutes.CreatePathForRoute(
 		routes.OAuthBegin,
 		rata.Params{"provider": ProviderName},
 	)
@@ -43,12 +43,22 @@ func (*GitHubAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.Au
 		panic("failed to construct oauth begin handler route: " + err.Error())
 	}
 
-	path = path + fmt.Sprintf("?team_name=%s", teamName)
+	tokenLogin, err := routes.OAuthRoutes.CreatePathForRoute(
+		routes.Token,
+		rata.Params{"provider": ProviderName},
+	)
+	if err != nil {
+		panic("failed to construct token login handler route: " + err.Error())
+	}
+
+	oauthBegin = oauthBegin + fmt.Sprintf("?team_name=%s", teamName)
+	tokenLogin = tokenLogin + fmt.Sprintf("?team_name=%s", teamName)
 
 	return atc.AuthMethod{
 		Type:        atc.AuthTypeOAuth,
 		DisplayName: DisplayName,
-		AuthURL:     oauthBaseURL + path,
+		AuthURL:     oauthBaseURL + oauthBegin,
+		TokenURL:    oauthBaseURL + tokenLogin,
 	}
 }
 

--- a/auth/github/provider_test.go
+++ b/auth/github/provider_test.go
@@ -23,6 +23,7 @@ var _ = Describe("GitHub Provider", func() {
 				Type:        atc.AuthTypeOAuth,
 				DisplayName: "GitHub",
 				AuthURL:     "http://bum-bum-bum.com/auth/github?team_name=dudududum",
+				TokenURL:    "http://bum-bum-bum.com/auth/github/token?team_name=dudududum",
 			}))
 		})
 	})

--- a/auth/gitlab/provider.go
+++ b/auth/gitlab/provider.go
@@ -35,7 +35,7 @@ type GitLabAuthConfig struct {
 }
 
 func (*GitLabAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.AuthMethod {
-	path, err := routes.OAuthRoutes.CreatePathForRoute(
+	oauthBegin, err := routes.OAuthRoutes.CreatePathForRoute(
 		routes.OAuthBegin,
 		rata.Params{"provider": ProviderName},
 	)
@@ -43,12 +43,22 @@ func (*GitLabAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.Au
 		panic("failed to construct oauth begin handler route: " + err.Error())
 	}
 
-	path = path + fmt.Sprintf("?team_name=%s", teamName)
+	tokenLogin, err := routes.OAuthRoutes.CreatePathForRoute(
+		routes.Token,
+		rata.Params{"provider": ProviderName},
+	)
+	if err != nil {
+		panic("failed to construct token login handler route: " + err.Error())
+	}
+
+	oauthBegin = oauthBegin + fmt.Sprintf("?team_name=%s", teamName)
+	tokenLogin = tokenLogin + fmt.Sprintf("?team_name=%s", teamName)
 
 	return atc.AuthMethod{
 		Type:        atc.AuthTypeOAuth,
 		DisplayName: DisplayName,
-		AuthURL:     oauthBaseURL + path,
+		AuthURL:     oauthBaseURL + oauthBegin,
+		TokenURL:    oauthBaseURL + tokenLogin,
 	}
 }
 

--- a/auth/gitlab/provider_test.go
+++ b/auth/gitlab/provider_test.go
@@ -27,6 +27,7 @@ var _ = Describe("GitLab Provider", func() {
 				Type:        atc.AuthTypeOAuth,
 				DisplayName: "GitLab",
 				AuthURL:     "http://bum-bum-bum.com/auth/gitlab?team_name=dudududum",
+				TokenURL:    "http://bum-bum-bum.com/auth/gitlab/token?team_name=dudududum",
 			}))
 		})
 	})

--- a/auth/token_handler.go
+++ b/auth/token_handler.go
@@ -101,7 +101,7 @@ func (handler *TokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	verified, err := provider.Verify(handler.logger, tc)
 	if err != nil {
 		handler.logger.Error("error-while-verifying-user", err)
-		http.Error(w, "error durring verification", http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if !verified {

--- a/auth/uaa/provider.go
+++ b/auth/uaa/provider.go
@@ -77,7 +77,7 @@ func (f *FileContentsFlag) UnmarshalFlag(value string) error {
 }
 
 func (*UAAAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.AuthMethod {
-	path, err := routes.OAuthRoutes.CreatePathForRoute(
+	oauthBegin, err := routes.OAuthRoutes.CreatePathForRoute(
 		routes.OAuthBegin,
 		rata.Params{"provider": ProviderName},
 	)
@@ -85,12 +85,22 @@ func (*UAAAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.AuthM
 		panic("failed to construct oauth begin handler route: " + err.Error())
 	}
 
-	path = path + fmt.Sprintf("?team_name=%s", teamName)
+	tokenLogin, err := routes.OAuthRoutes.CreatePathForRoute(
+		routes.Token,
+		rata.Params{"provider": ProviderName},
+	)
+	if err != nil {
+		panic("failed to construct token login handler route: " + err.Error())
+	}
+
+	oauthBegin = oauthBegin + fmt.Sprintf("?team_name=%s", teamName)
+	tokenLogin = tokenLogin + fmt.Sprintf("?team_name=%s", teamName)
 
 	return atc.AuthMethod{
 		Type:        atc.AuthTypeOAuth,
 		DisplayName: DisplayName,
-		AuthURL:     oauthBaseURL + path,
+		AuthURL:     oauthBaseURL + oauthBegin,
+		TokenURL:    oauthBaseURL + tokenLogin,
 	}
 }
 

--- a/auth/uaa/provider_test.go
+++ b/auth/uaa/provider_test.go
@@ -149,6 +149,7 @@ K4iijxtW0XYe5R1Od6lWOEKZ6un9Ag==
 				Type:        atc.AuthTypeOAuth,
 				DisplayName: "UAA",
 				AuthURL:     "http://bum-bum-bum.com/auth/uaa?team_name=dudududum",
+				TokenURL:    "http://bum-bum-bum.com/auth/uaa/token?team_name=dudududum",
 			}))
 		})
 	})


### PR DESCRIPTION
@jtarchie 
@vito 
@chendrix 

Please review & merge.
This is linked to https://github.com/concourse/fly/pull/185 and needs to be merged first.

This PR enables the ATC to return the following structure on `api/v1/teams/:team_name/auth/methods`:

```    
{
        "auth_url": "http://127.0.0.1:8080/auth/github?team_name=openCloak",
        "display_name": "GitHub",
        "token_url": "http://127.0.0.1:8080/auth/github/token?team_name=openCloak",
        "type": "oauth"
}
```

Note the added `token_url`