### PR TITLE
Utilize a proxy when configured for OAuth exchange

### DIFF
--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -177,6 +177,7 @@ func (provider Provider) Client(ctx context.Context, t *oauth2.Token) *http.Clie
 func (Provider) PreTokenClient() (*http.Client, error) {
 	return &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			DisableKeepAlives: true,
 		},
 	}, nil

--- a/auth/github/provider.go
+++ b/auth/github/provider.go
@@ -163,6 +163,7 @@ func (GitHubTeamProvider) ProviderConstructor(
 func (GitHubProvider) PreTokenClient() (*http.Client, error) {
 	return &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			DisableKeepAlives: true,
 		},
 	}, nil

--- a/auth/gitlab/provider.go
+++ b/auth/gitlab/provider.go
@@ -146,6 +146,7 @@ func (GitLabTeamProvider) ProviderConstructor(
 func (GitLabProvider) PreTokenClient() (*http.Client, error) {
 	return &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			DisableKeepAlives: true,
 		},
 	}, nil

--- a/auth/uaa/provider.go
+++ b/auth/uaa/provider.go
@@ -182,6 +182,7 @@ func (UAATeamProvider) ProviderConstructor(
 
 func (p UAAProvider) PreTokenClient() (*http.Client, error) {
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		DisableKeepAlives: true,
 	}
 


### PR DESCRIPTION
Addresses issue described in concourse/concourse#1337 where the token exchange fails when using a proxy.