### PR TITLE
add version to image_resource

### DIFF
--- a/exec/task_action.go
+++ b/exec/task_action.go
@@ -316,9 +316,10 @@ func (action *TaskAction) containerSpec(logger lager.Logger, repository *worker.
 		imageSpec.ImageArtifactName = worker.ArtifactName(action.imageArtifactName)
 	} else if config.ImageResource != nil {
 		imageSpec.ImageResource = &worker.ImageResource{
-			Type:   config.ImageResource.Type,
-			Source: creds.NewSource(action.variables, config.ImageResource.Source),
-			Params: config.ImageResource.Params,
+			Type:    config.ImageResource.Type,
+			Source:  creds.NewSource(action.variables, config.ImageResource.Source),
+			Params:  config.ImageResource.Params,
+			Version: config.ImageResource.Version,
 		}
 	} else if config.RootfsURI != "" {
 		imageSpec.ImageURL = config.RootfsURI

--- a/exec/task_action_test.go
+++ b/exec/task_action_test.go
@@ -149,9 +149,10 @@ var _ = Describe("TaskAction", func() {
 			fetchedConfig = atc.TaskConfig{
 				Platform: "some-platform",
 				ImageResource: &atc.ImageResource{
-					Type:   "docker",
-					Source: atc.Source{"some": "((source-param))"},
-					Params: atc.Params{"some": "params"},
+					Type:    "docker",
+					Source:  atc.Source{"some": "((source-param))"},
+					Params:  atc.Params{"some": "params"},
+					Version: atc.Version{"some": "version"},
 				},
 				Params: map[string]string{
 					"SECURE": "((task-param))",
@@ -208,9 +209,10 @@ var _ = Describe("TaskAction", func() {
 					TeamID:   teamID,
 					ImageSpec: worker.ImageSpec{
 						ImageResource: &worker.ImageResource{
-							Type:   "docker",
-							Source: creds.NewSource(variables, atc.Source{"some": "((source-param))"}),
-							Params: atc.Params{"some": "params"},
+							Type:    "docker",
+							Source:  creds.NewSource(variables, atc.Source{"some": "((source-param))"}),
+							Params:  atc.Params{"some": "params"},
+							Version: atc.Version{"some": "version"},
 						},
 						Privileged: false,
 					},
@@ -1147,9 +1149,10 @@ var _ = Describe("TaskAction", func() {
 										configWithImageResource := atc.TaskConfig{
 											Platform: "some-platform",
 											ImageResource: &atc.ImageResource{
-												Type:   "docker",
-												Source: atc.Source{"some": "super-secret-source"},
-												Params: atc.Params{"some": "params"},
+												Type:    "docker",
+												Source:  atc.Source{"some": "super-secret-source"},
+												Params:  atc.Params{"some": "params"},
+												Version: atc.Version{"some": "version"},
 											},
 											Params: map[string]string{"SOME": "params"},
 											Run: atc.TaskRunConfig{
@@ -1176,9 +1179,10 @@ var _ = Describe("TaskAction", func() {
 											Platform:  "some-platform",
 											RootfsURI: "some-image",
 											ImageResource: &atc.ImageResource{
-												Type:   "docker",
-												Source: atc.Source{"some": "super-secret-source"},
-												Params: atc.Params{"some": "params"},
+												Type:    "docker",
+												Source:  atc.Source{"some": "super-secret-source"},
+												Params:  atc.Params{"some": "params"},
+												Version: atc.Version{"some": "version"},
 											},
 											Params: map[string]string{"SOME": "params"},
 											Run: atc.TaskRunConfig{

--- a/exec/task_config_fetcher_test.go
+++ b/exec/task_config_fetcher_test.go
@@ -29,9 +29,10 @@ var _ = Describe("TaskConfigFetcher", func() {
 			Platform:  "some-platform",
 			RootfsURI: "some-image",
 			ImageResource: &atc.ImageResource{
-				Type:   "docker",
-				Source: atc.Source{"a": "b"},
-				Params: atc.Params{"some": "params"},
+				Type:    "docker",
+				Source:  atc.Source{"a": "b"},
+				Params:  atc.Params{"some": "params"},
+				Version: atc.Version{"some": "version"},
 			},
 			Params: map[string]string{
 				"task-config-param-key": "task-config-param-val-1",

--- a/task.go
+++ b/task.go
@@ -37,9 +37,10 @@ type TaskConfig struct {
 }
 
 type ImageResource struct {
-	Type   string `yaml:"type" json:"type" mapstructure:"type"`
-	Source Source `yaml:"source" json:"source" mapstructure:"source"`
-	Params Params `yaml:"params" json:"params" mapstructure:"params"`
+	Type    string  `yaml:"type" json:"type" mapstructure:"type"`
+	Source  Source  `yaml:"source" json:"source" mapstructure:"source"`
+	Params  Params  `yaml:"params" json:"params" mapstructure:"params"`
+	Version Version `yaml:"version" json:"version" mapstructure:"version"`
 }
 
 func NewTaskConfig(configBytes []byte) (TaskConfig, error) {

--- a/worker/container_spec.go
+++ b/worker/container_spec.go
@@ -50,9 +50,10 @@ type ImageSpec struct {
 }
 
 type ImageResource struct {
-	Type   string
-	Source creds.Source
-	Params atc.Params
+	Type    string
+	Source  creds.Source
+	Params  atc.Params
+	Version atc.Version
 }
 
 func (spec ContainerSpec) WorkerSpec() WorkerSpec {

--- a/worker/image/image_factory.go
+++ b/worker/image/image_factory.go
@@ -86,7 +86,7 @@ func (f *imageFactory) GetImage(
 			workerClient,
 			resourceUser,
 			*imageSpec.ImageResource,
-			nil,
+			imageSpec.ImageResource.Version,
 			teamID,
 			resourceTypes,
 			delegate,


### PR DESCRIPTION
I haven't tested this; I made these changes based on the addition of params to image_resource, which seems more complicated than adding version.

The reason for wanting this is basically what it says on the tin: so we can pin a specific version of the resource that's used for image_resource.

In the particular use case I have in mind for this feature, we have an S3 bucket being used to supply the rootfs for the task. We also need to bless particular combinations of versions, down to the rootfs, to ensure they work together. This feature gives us the ability to pin not just the normal resource gets but the image_resource rootfs as well.