### PR TITLE
Set headers to stop badge caching

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -356,6 +356,12 @@ var _ = Describe("Jobs API", func() {
 				Expect(response.StatusCode).To(Equal(http.StatusOK))
 			})
 
+			It("returns Content-Type as image/svg+xml and disables caching", func() {
+				Expect(response.Header.Get("Content-Type")).To(Equal("image/svg+xml"))
+				Expect(response.Header.Get("Cache-Control")).To(Equal("no-cache, no-store, must-revalidate"))
+				Expect(response.Header.Get("Expires")).To(Equal("0"))
+			})
+
 			Context("when the finished build is successful", func() {
 				BeforeEach(func() {
 					build1 := new(dbfakes.FakeBuild)

--- a/api/jobserver/badge.go
+++ b/api/jobserver/badge.go
@@ -123,6 +123,9 @@ func (s *Server) JobBadge(pipeline db.Pipeline) http.Handler {
 
 		w.Header().Set("Content-type", "image/svg+xml")
 
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Expires", "0")
+
 		w.WriteHeader(http.StatusOK)
 
 		fmt.Fprint(w, badgeForBuild(build))


### PR DESCRIPTION
Sets the appropriate headers that stop github from caching badges. Badge caching can mislead developers with regard to the current status of their build.

Fixed according to @bkeepers comments in [github/markup issue #224](https://github.com/github/markup/issues/224#issuecomment-48532178):

> We're pretty confident that the image caching works. If you're having issues with something like a CI badge, make sure the image has the Cache-Control: no-cache header, and either Expires, Last-Modified or Etag. See the Fastly documentation for more info.

[fixes concourse/concourse#835]
[finishes #136613913]