### PR TITLE
Don't cache badges; they might get stale

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -356,6 +356,11 @@ var _ = Describe("Jobs API", func() {
 				Expect(response.StatusCode).To(Equal(http.StatusOK))
 			})
 
+			It("returns Content-Type as image/svg+xml and disables caching", func() {
+				Expect(response.Header.Get("Content-Type")).To(Equal("image/svg+xml"))
+				Expect(response.Header.Get("Cache-Control")).To(Equal("no-cache, no-store, must-revalidate"))
+			})
+
 			Context("when the finished build is successful", func() {
 				BeforeEach(func() {
 					build1 := new(dbfakes.FakeBuild)

--- a/api/jobserver/badge.go
+++ b/api/jobserver/badge.go
@@ -122,6 +122,7 @@ func (s *Server) JobBadge(pipeline db.Pipeline) http.Handler {
 		}
 
 		w.Header().Set("Content-type", "image/svg+xml")
+		w.Header().Add("Cache-Control", "no-cache, no-store, must-revalidate")
 
 		w.WriteHeader(http.StatusOK)
 


### PR DESCRIPTION
Per @beyhan:

> Github has aggressive image caching which breaks CI badges. See [issue](https://github.com/github/markup/issues/224). Concourse doesn't set the Cache-Control header to no-cache which is expected by Github.

We set the `Cache-Control` headers to `no-cache, no-store, must-revalidate` because that's what it's set to in [this commit](https://github.com/concourse/atc/commit/3740efa), and we want consistency within the codebase.

A longer explanation of the various cache controls can be found [here](https://stackoverflow.com/questions/49547/how-to-control-web-page-caching-across-all-browsers).

We've chosen not to implement all the controls because they are not relevant to the audience who is viewing Concourse badges on GitHub (e.g. they are not using Internet Explorer 6), and, as aforementioned, we'd like to be consistent with the rest of the codebase.

[fixes concourse/concourse#835]
[finishes #136613913]