### PR TITLE
Change the resource_caches index to use md5 of version

### DIFF
--- a/db/migrations/182_use_md5_for_resource_cache_versions.go
+++ b/db/migrations/182_use_md5_for_resource_cache_versions.go
@@ -1,0 +1,22 @@
+package migrations
+
+import "github.com/concourse/atc/db/migration"
+
+func UseMd5ForResourceCacheVersions(tx migration.LimitedTx) error {
+	_, err := tx.Exec(`
+		ALTER TABLE resource_caches DROP CONSTRAINT "resource_caches_resource_config_id_version_params_hash_key";
+`)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`
+		CREATE UNIQUE INDEX resource_caches_resource_config_id_version_params_hash_key
+		ON resource_caches (resource_config_id, md5(version), params_hash);
+	`)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -197,5 +197,6 @@ func New(strategy EncryptionStrategy) []migration.Migrator {
 		AddViewsForBuildStates,
 		AddUniqueIndexesToMaterializedViews,
 		AddFailedStateToVolumes,
+		UseMd5ForResourceCacheVersions,
 	}
 }


### PR DESCRIPTION
The version can potentially become too long, and creating an index for
the columns will fail. See https://github.com/concourse/concourse-pipeline-resource/issues/22
for an issue.