### PR TITLE
Error if multiple emitters are configured.

### DIFF
--- a/metric/emit.go
+++ b/metric/emit.go
@@ -2,6 +2,7 @@ package metric
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	flags "github.com/jessevdk/go-flags"
@@ -61,6 +62,16 @@ type eventEmission struct {
 var emissions = make(chan eventEmission, 1000)
 
 func Initialize(logger lager.Logger, host string, attributes map[string]string) error {
+	var emitterDescriptions []string
+	for _, factory := range emitterFactories {
+		if factory.IsConfigured() {
+			emitterDescriptions = append(emitterDescriptions, factory.Description())
+		}
+	}
+	if len(emitterDescriptions) > 1 {
+		return fmt.Errorf("Multiple emitters configured: %s", strings.Join(emitterDescriptions, ", "))
+	}
+
 	var err error
 	for _, factory := range emitterFactories {
 		if factory.IsConfigured() {


### PR DESCRIPTION
If multiple emitters are configured, only one is used; the others are
silently ignored. This patch causes the atc to fail if multiple emitters
are configured so that users don't expect that multiple emitters are
supported.

[Closes https://github.com/concourse/concourse/issues/1557]

h/t @jtarchie