### PR TITLE
Add option to use LetsEncrypt to obtain TLS certificates

### DIFF
--- a/atccmd/cert_cache.go
+++ b/atccmd/cert_cache.go
@@ -1,0 +1,61 @@
+package atccmd
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/concourse/atc/db"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+type dbCache struct {
+	get, put, delete *sql.Stmt
+	es               db.EncryptionStrategy
+}
+
+func newDbCache(conn db.Conn) (autocert.Cache, error) {
+	c := new(dbCache)
+	c.es = conn.EncryptionStrategy()
+	var err error
+	c.get, err = conn.Prepare("SELECT data, nonce FROM cert_cache WHERE key = $1")
+	if err != nil {
+		return nil, err
+	}
+	c.put, err = conn.Prepare("INSERT INTO cert_cache (key, data, nonce) VALUES ($1, $2, $3)")
+	if err != nil {
+		return nil, err
+	}
+	c.delete, err = conn.Prepare("DELETE FROM cert_cache WHERE key = $1")
+	return c, err
+}
+
+func (c *dbCache) Get(ctx context.Context, key string) ([]byte, error) {
+	var ciphertext string
+	var nonce sql.NullString
+	err := c.get.QueryRowContext(ctx, key).Scan(&ciphertext, &nonce)
+	if err == sql.ErrNoRows {
+		err = autocert.ErrCacheMiss
+	}
+	if err != nil {
+		return nil, err
+	}
+	var noncense *string
+	if nonce.Valid {
+		noncense = &nonce.String
+	}
+	return c.es.Decrypt(ciphertext, noncense)
+}
+
+func (c *dbCache) Put(ctx context.Context, key string, data []byte) error {
+	ciphertext, nonce, err := c.es.Encrypt(data)
+	if err != nil {
+		return err
+	}
+	_, err = c.put.ExecContext(ctx, key, ciphertext, nonce)
+	return err
+}
+
+func (c *dbCache) Delete(ctx context.Context, key string) error {
+	_, err := c.delete.ExecContext(ctx, key)
+	return err
+}

--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -593,8 +593,13 @@ func (cmd *ATCCommand) Runner(args []string) (ifrit.Runner, error) {
 	if httpsHandler != nil {
 		var tlsConfig *tls.Config
 		if cmd.Autocert {
+			cache, err := newDbCache(dbConn)
+			if err != nil {
+				return nil, err
+			}
 			m := autocert.Manager{
 				Prompt:     autocert.AcceptTOS,
+				Cache:      cache,
 				HostPolicy: autocert.HostWhitelist(cmd.ExternalURL.URL().Hostname()),
 				Client:     &acme.Client{DirectoryURL: cmd.ACMEURL.URL().String()},
 			}

--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -52,6 +52,8 @@ import (
 	"github.com/tedsuo/ifrit/http_server"
 	"github.com/tedsuo/ifrit/sigmon"
 	"github.com/xoebus/zest"
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/concourse/atc/auth/provider"
 	"github.com/concourse/atc/auth/routes"
@@ -76,9 +78,11 @@ type ATCCommand struct {
 	BindIP   IPFlag `long:"bind-ip"   default:"0.0.0.0" description:"IP address on which to listen for web traffic."`
 	BindPort uint16 `long:"bind-port" default:"8080"    description:"Port on which to listen for HTTP traffic."`
 
-	TLSBindPort uint16   `long:"tls-bind-port" description:"Port on which to listen for HTTPS traffic."`
-	TLSCert     FileFlag `long:"tls-cert"      description:"File containing an SSL certificate."`
-	TLSKey      FileFlag `long:"tls-key"       description:"File containing an RSA private key, used to encrypt HTTPS traffic."`
+	TLSBindPort uint16   `long:"tls-bind-port"                                                     description:"Port on which to listen for HTTPS traffic."`
+	TLSCert     FileFlag `long:"tls-cert"                                                          description:"File containing an SSL certificate."`
+	TLSKey      FileFlag `long:"tls-key"                                                           description:"File containing an RSA private key, used to encrypt HTTPS traffic."`
+	Autocert    bool     `long:"autocert"                                                          description:"Use ACME to obtain an SSL certificate."`
+	ACMEURL     URLFlag  `long:"acme-url" default:"https://acme-v01.api.letsencrypt.org/directory" description:"URL of the ACME CA directory endpoint."`
 
 	ExternalURL URLFlag `long:"external-url" default:"http://127.0.0.1:8080" description:"URL used to reach any ATC from the outside world."`
 	PeerURL     URLFlag `long:"peer-url"     default:"http://127.0.0.1:8080" description:"URL used to reach this ATC from other ATCs in the cluster."`
@@ -587,14 +591,27 @@ func (cmd *ATCCommand) Runner(args []string) (ifrit.Runner, error) {
 	}
 
 	if httpsHandler != nil {
-		cert, err := tls.LoadX509KeyPair(string(cmd.TLSCert), string(cmd.TLSKey))
-		if err != nil {
-			return nil, err
-		}
+		var tlsConfig *tls.Config
+		if cmd.Autocert {
+			m := autocert.Manager{
+				Prompt:     autocert.AcceptTOS,
+				HostPolicy: autocert.HostWhitelist(cmd.ExternalURL.URL().Hostname()),
+				Client:     &acme.Client{DirectoryURL: cmd.ACMEURL.URL().String()},
+			}
+			tlsConfig = &tls.Config{
+				GetCertificate: m.GetCertificate,
+				NextProtos:     []string{"h2"},
+			}
+		} else {
+			cert, err := tls.LoadX509KeyPair(string(cmd.TLSCert), string(cmd.TLSKey))
+			if err != nil {
+				return nil, err
+			}
 
-		tlsConfig := &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			NextProtos:   []string{"h2"},
+			tlsConfig = &tls.Config{
+				Certificates: []tls.Certificate{cert},
+				NextProtos:   []string{"h2"},
+			}
 		}
 
 		members = append(members, grouper.Member{"web-tls", http_server.NewTLSServer(
@@ -683,28 +700,39 @@ func (cmd *ATCCommand) validate() error {
 		)
 	}
 
-	tlsFlagCount := 0
-	if cmd.TLSBindPort != 0 {
-		tlsFlagCount++
-	}
-	if cmd.TLSCert != "" {
-		tlsFlagCount++
-	}
-	if cmd.TLSKey != "" {
-		tlsFlagCount++
-	}
-
-	if tlsFlagCount == 3 {
+	switch {
+	case cmd.TLSBindPort == 0:
+		if cmd.TLSCert != "" || cmd.TLSKey != "" || cmd.Autocert {
+			errs = multierror.Append(
+				errs,
+				errors.New("must specify --tls-bind-port to use TLS"),
+			)
+		}
+	case cmd.Autocert:
+		if cmd.TLSCert != "" || cmd.TLSKey != "" {
+			errs = multierror.Append(
+				errs,
+				errors.New("cannot enable autocert if --tls-cert or --tls-key are set"),
+			)
+		}
+		if p := cmd.ExternalURL.URL().Port(); !(p == "" || p == "443") {
+			errs = multierror.Append(
+				errs,
+				errors.New("cannot enable autocert if external port is not 443"),
+			)
+		}
+		fallthrough
+	case cmd.TLSCert != "" && cmd.TLSKey != "":
 		if cmd.ExternalURL.URL().Scheme != "https" {
 			errs = multierror.Append(
 				errs,
 				errors.New("must specify HTTPS external-url to use TLS"),
 			)
 		}
-	} else if tlsFlagCount != 0 {
+	default:
 		errs = multierror.Append(
 			errs,
-			errors.New("must specify --tls-bind-port, --tls-cert, --tls-key to use TLS"),
+			errors.New("must specify --tls-cert and --tls-key, or --autocert to use TLS"),
 		)
 	}
 

--- a/db/migrations/182_add_cert_cache.go
+++ b/db/migrations/182_add_cert_cache.go
@@ -1,0 +1,14 @@
+package migrations
+
+import "github.com/concourse/atc/db/migration"
+
+func AddCertCache(tx migration.LimitedTx) error {
+	_, err := tx.Exec(`
+		CREATE TABLE cert_cache (
+			key text PRIMARY KEY,
+			data text NOT NULL,
+			nonce text
+		)
+	`)
+	return err
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -197,5 +197,6 @@ func New(strategy EncryptionStrategy) []migration.Migrator {
 		AddViewsForBuildStates,
 		AddUniqueIndexesToMaterializedViews,
 		AddFailedStateToVolumes,
+		AddCertCache,
 	}
 }

--- a/db/open.go
+++ b/db/open.go
@@ -103,6 +103,7 @@ var encryptedColumns = map[string]string{
 	"jobs":           "config",
 	"resource_types": "config",
 	"builds":         "engine_metadata",
+	"cert_cache":     "data",
 }
 
 func encryptPlaintext(logger lager.Logger, sqlDB *sql.DB, key *EncryptionKey) error {


### PR DESCRIPTION
Adds the option `--autocert` which can be used instead of `--tls-cert` and `--tls-key`.

If `--autocert` is given, ATC will generate a key and certificate, then, using the ACME protocol, get the certificate signed and start using it to serve HTTPS. The ACME provider defaults to LetsEncrypt but can be changed with the `--acme-url` option.

When `--autocert` is used, ATC will handle certificate expiration by renewing the certificate it has previously obtained when that certificate's expiry date is less than 30 days time. This happens without impacting the availability of the server.

ATC will cache certificates it has obtained using ACME in the database table `cert_cache`. This done because LetsEncrypt implements severe rate limiting on obtaining duplicate certificates. Only 5 certificate with the same set of requested hostnames will be issued in any given 7 day period.

Fixes [#918](https://github.com/concourse/concourse/issues/918)