### PR TITLE
Validate inline task config when validating pipeline config.

### DIFF
--- a/api/config_test.go
+++ b/api/config_test.go
@@ -95,7 +95,11 @@ var _ = Describe("Config API", func() {
 							Task:       "some-task",
 							Privileged: true,
 							TaskConfig: &atc.TaskConfig{
+								Platform:  "linux",
 								RootfsURI: "some-image",
+								Run: atc.TaskRunConfig{
+									Path: "/path/to/run",
+								},
 							},
 						},
 						{
@@ -193,7 +197,11 @@ var _ = Describe("Config API", func() {
 										Task:       "some-task",
 										Privileged: true,
 										TaskConfig: &atc.TaskConfig{
+											Platform:  "linux",
 											RootfsURI: "some-image",
+											Run: atc.TaskRunConfig{
+												Path: "/path/to/run",
+											},
 										},
 									},
 									{
@@ -564,6 +572,7 @@ jobs:
   - get: some-resource
   - task: some-task
     config:
+      platform: linux
       run:
         path: ls
       params:
@@ -603,6 +612,8 @@ jobs:
 												{
 													Task: "some-task",
 													TaskConfig: &atc.TaskConfig{
+														Platform: "linux",
+
 														Run: atc.TaskRunConfig{
 															Path: "ls",
 														},

--- a/task.go
+++ b/task.go
@@ -335,8 +335,8 @@ func (config TaskConfig) validateInputContainsNames() []string {
 
 type TaskRunConfig struct {
 	Path string   `json:"path" yaml:"path"`
-	Args []string `json:"args,omitempty" yaml:"args"`
-	Dir  string   `json:"dir,omitempty" yaml:"dir"`
+	Args []string `json:"args,omitempty" yaml:"args,omitempty"`
+	Dir  string   `json:"dir,omitempty" yaml:"dir,omitempty"`
 
 	// The user that the task will run as (defaults to whatever the docker image specifies)
 	User string `json:"user,omitempty" yaml:"user,omitempty" mapstructure:"user"`

--- a/validate.go
+++ b/validate.go
@@ -460,6 +460,15 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]Warning, []st
 			warnings = append(warnings, newDeprecationWarning(identifier+" specifies both `file` and `config` in a task step"))
 		}
 
+		if plan.TaskConfig != nil {
+			if err := plan.TaskConfig.Validate(); err != nil {
+				messages := strings.Split(err.Error(), "\n")
+				for _, message := range messages {
+					errorMessages = append(errorMessages, fmt.Sprintf("%s %s", identifier, strings.TrimSpace(message)))
+				}
+			}
+		}
+
 		errorMessages = append(errorMessages, validateInapplicableFields(
 			[]string{"resource", "passed", "trigger"},
 			plan, identifier)...,

--- a/validate_test.go
+++ b/validate_test.go
@@ -664,6 +664,28 @@ var _ = Describe("ValidateConfig", func() {
 				})
 			})
 
+			Context("when a task plan is invalid", func() {
+				BeforeEach(func() {
+					job.Plan = append(job.Plan, PlanConfig{
+						Task: "some-resource",
+						TaskConfig: &TaskConfig{
+							Params: map[string]string{
+								"param1": "value1",
+							},
+						},
+					})
+
+					config.Jobs = append(config.Jobs, job)
+				})
+
+				It("returns an error", func() {
+					Expect(errorMessages).To(HaveLen(1))
+					Expect(errorMessages[0]).To(ContainSubstring("invalid jobs:"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan[0].task.some-resource missing 'platform'"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan[0].task.some-resource missing path to executable to run"))
+				})
+			})
+
 			Context("when a put plan has invalid fields specified", func() {
 				BeforeEach(func() {
 					job.Plan = append(job.Plan, PlanConfig{


### PR DESCRIPTION
[Resolves https://github.com/concourse/concourse/issues/1644]

Note: this is a hacky implementation, since `TaskConfig.Validate` returns `error` instead of `[]string`. Happy to refactor `TaskConfig` a bit to avoid string parsing if you want.