### PR TITLE
We should install elm to successfully build atc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ brew install go node postgres
 Finally use Node to install the javascript tools:
 
 ```
-npm install -g uglify-js less less-plugin-clean-css
+npm install -g elm uglify-js less less-plugin-clean-css
 ```
 
 ## Setting up the database


### PR DESCRIPTION
The build fails due to missing an elm binary without `npm install`ing it:

```
$ make -B
cd elm && elm make --warn --output ../public/elm.js --yes src/Main.elm
/bin/sh: elm: command not found
make: *** [public/elm.js] Error 127
```