### PR TITLE
We should provide an auth flag when running atc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Finally you can run the ATC:
 
 ```
 cd ..
-go run cmd/atc/*.go
+go run cmd/atc/*.go --no-really-i-dont-want-any-auth
 ```
 
 Concourse should be live at http://localhost:8080


### PR DESCRIPTION
The `go run` command fails like this without a flag:

```
$ go run cmd/atc/*.go
1 error occurred:

* must configure basic auth, OAuth, UAAAuth, or provide no-auth flag
exit status 1
```