### PR TITLE
Fix panic that occurred when "insecure-skip-verify" was not set.

### DIFF
--- a/creds/credhub/manager.go
+++ b/creds/credhub/manager.go
@@ -52,15 +52,18 @@ func (manager CredHubManager) Validate() error {
 }
 
 func (manager CredHubManager) NewVariablesFactory(logger lager.Logger) (creds.VariablesFactory, error) {
-	var skipTls credhub.Option
+	var options []credhub.Option
 
 	if manager.Insecure {
-		skipTls = credhub.SkipTLSValidation()
+		options = append(options, credhub.SkipTLSValidation())
 	}
 
-	ch, err := credhub.New(manager.URL,
-		skipTls,
-		credhub.Auth(auth.UaaClientCredentials(manager.ClientId, manager.ClientSecret)))
+	options = append(options, credhub.Auth(auth.UaaClientCredentials(manager.ClientId, manager.ClientSecret)))
 
-	return NewCredHubFactory(logger, ch, manager.PathPrefix), err
+	ch, err := credhub.New(manager.URL, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCredHubFactory(logger, ch, manager.PathPrefix), nil
 }


### PR DESCRIPTION
Previously an "empty" function was passed to credhub.New() which promptly panicked.

Change error handling to fail fast if an error is returned.