### PR TITLE
Return an error if an unrecognized positional argument is returned.

### DIFF
--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -208,7 +208,10 @@ func (cmd *ATCCommand) Execute(args []string) error {
 	return <-ifrit.Invoke(sigmon.New(runner)).Wait()
 }
 
-func (cmd *ATCCommand) Runner(args []string) (ifrit.Runner, error) {
+func (cmd *ATCCommand) Runner(positionalArguments []string) (ifrit.Runner, error) {
+	if len(positionalArguments) != 0 {
+		return nil, fmt.Errorf("unexpected positional arguments: %v", positionalArguments)
+	}
 	err := cmd.validate()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For example, `--credhub-insecure-skip-verify false`

(boolean flags don't take values, so false is ignored)

 (the bosh release currently generates: `--credhub-insecure-skip-verify true`, I haven't checked to see what happens if `false` is specified, that's my next PR)