### PR TITLE
Add support for renaming teams on the API

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -209,6 +209,7 @@ func NewHandler(
 
 		atc.ListTeams:   http.HandlerFunc(teamServer.ListTeams),
 		atc.SetTeam:     http.HandlerFunc(teamServer.SetTeam),
+		atc.RenameTeam:  http.HandlerFunc(teamServer.RenameTeam),
 		atc.DestroyTeam: http.HandlerFunc(teamServer.DestroyTeam),
 	}
 

--- a/api/teamserver/rename.go
+++ b/api/teamserver/rename.go
@@ -1,0 +1,74 @@
+package teamserver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/concourse/atc"
+	"github.com/concourse/atc/auth"
+)
+
+// RenameTeam allows an authed user with authority or admin to rename a team
+func (s *Server) RenameTeam(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.Session("rename-team")
+
+	authTeam, authTeamFound := auth.GetTeam(r)
+	if !authTeamFound {
+		logger.Error("failed-to-get-team-from-auth", errors.New("failed-to-get-team-from-auth"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	teamName := r.FormValue(":team_name")
+	if !authTeam.IsAdmin() && !authTeam.IsAuthorized(teamName) {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		logger.Error("failed-to-read-body", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	var rename atc.RenameRequest
+	err = json.Unmarshal(data, &rename)
+	if err != nil {
+		logger.Error("failed-to-unmarshal-body", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	team, found, err := s.teamFactory.FindTeam(teamName)
+	if err != nil {
+		logger.Error("failed-to-get-team", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !found {
+		logger.Info("team-not-found")
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	fmt.Println(team.Name(), atc.DefaultTeamName)
+	if team.Name() == atc.DefaultTeamName {
+		logger.Info("team-is-default-admin-team")
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	err = team.Rename(rename.NewName)
+	if err != nil {
+		logger.Error("failed-to-update-team-name", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/db/dbfakes/fake_team.go
+++ b/db/dbfakes/fake_team.go
@@ -67,6 +67,15 @@ type FakeTeam struct {
 	deleteReturnsOnCall map[int]struct {
 		result1 error
 	}
+	RenameStub        func(string) error
+	renameMutex       sync.RWMutex
+	renameArgsForCall []struct{ name string }
+	renameReturns     struct {
+		result1 error
+	}
+	renameReturnsOnCall map[int]struct {
+		result1 error
+	}
 	SavePipelineStub        func(pipelineName string, config atc.Config, from db.ConfigVersion, pausedState db.PipelinePausedState) (db.Pipeline, bool, error)
 	savePipelineMutex       sync.RWMutex
 	savePipelineArgsForCall []struct {
@@ -604,6 +613,33 @@ func (fake *FakeTeam) DeleteReturnsOnCall(i int, result1 error) {
 	fake.deleteReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeTeam) Rename(name string) error {
+	fake.renameMutex.Lock()
+	ret, specificReturn := fake.renameReturnsOnCall[len(fake.renameArgsForCall)]
+	fake.renameArgsForCall = append(fake.renameArgsForCall, struct{ name string }{name})
+	fake.recordInvocation("Rename", []interface{}{})
+	fake.renameMutex.Unlock()
+	if fake.RenameStub != nil {
+		return fake.RenameStub(name)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.renameReturns.result1
+}
+
+func (fake *FakeTeam) RenameCallCount() int {
+	fake.renameMutex.RLock()
+	defer fake.renameMutex.RUnlock()
+	return len(fake.renameArgsForCall)
+}
+
+func (fake *FakeTeam) RenameArgsForCall(i int) string {
+	fake.renameMutex.RLock()
+	defer fake.renameMutex.RUnlock()
+	return fake.renameArgsForCall[i].name
 }
 
 func (fake *FakeTeam) SavePipeline(pipelineName string, config atc.Config, from db.ConfigVersion, pausedState db.PipelinePausedState) (db.Pipeline, bool, error) {

--- a/db/team.go
+++ b/db/team.go
@@ -33,6 +33,7 @@ type Team interface {
 	Auth() map[string]*json.RawMessage
 
 	Delete() error
+	Rename(string) error
 
 	SavePipeline(
 		pipelineName string,
@@ -124,6 +125,18 @@ func (t *team) Delete() error {
 	}
 
 	return nil
+}
+
+func (t *team) Rename(name string) error {
+	_, err := psql.Update("teams").
+		Set("name", name).
+		Where(sq.Eq{
+			"id": t.id,
+		}).
+		RunWith(t.conn).
+		Exec()
+
+	return err
 }
 
 func (t *team) Workers() ([]Worker, error) {

--- a/db/team_test.go
+++ b/db/team_test.go
@@ -60,6 +60,16 @@ var _ = Describe("Team", func() {
 		})
 	})
 
+	Describe("Rename", func() {
+		JustBeforeEach(func() {
+			Expect(team.Rename("oopsies")).To(Succeed())
+		})
+
+		It("renames the team", func() {
+			Expect(team.Name()).To(Equal("oopsies"))
+		})
+	})
+
 	Describe("SaveWorker", func() {
 		var (
 			team      db.Team

--- a/routes.go
+++ b/routes.go
@@ -83,6 +83,7 @@ const (
 
 	ListTeams   = "ListTeams"
 	SetTeam     = "SetTeam"
+	RenameTeam  = "RenameTeam"
 	DestroyTeam = "DestroyTeam"
 )
 
@@ -167,5 +168,6 @@ var Routes = rata.Routes([]rata.Route{
 
 	{Path: "/api/v1/teams", Method: "GET", Name: ListTeams},
 	{Path: "/api/v1/teams/:team_name", Method: "PUT", Name: SetTeam},
+	{Path: "/api/v1/teams/:team_name/rename", Method: "PUT", Name: RenameTeam},
 	{Path: "/api/v1/teams/:team_name", Method: "DELETE", Name: DestroyTeam},
 })

--- a/wrappa/api_auth_wrappa.go
+++ b/wrappa/api_auth_wrappa.go
@@ -105,6 +105,7 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.HeartbeatWorker,
 			atc.DeleteWorker,
 			atc.SetTeam,
+			atc.RenameTeam,
 			atc.DestroyTeam,
 			atc.WritePipe,
 			atc.ListVolumes,

--- a/wrappa/api_auth_wrappa_test.go
+++ b/wrappa/api_auth_wrappa_test.go
@@ -264,6 +264,7 @@ var _ = Describe("APIAuthWrappa", func() {
 				atc.DeleteWorker:    authenticated(inputHandlers[atc.DeleteWorker]),
 
 				atc.SetTeam:     authenticated(inputHandlers[atc.SetTeam]),
+				atc.RenameTeam:  authenticated(inputHandlers[atc.RenameTeam]),
 				atc.DestroyTeam: authenticated(inputHandlers[atc.DestroyTeam]),
 				atc.WritePipe:   authenticated(inputHandlers[atc.WritePipe]),
 				atc.GetUser:     authenticated(inputHandlers[atc.GetUser]),


### PR DESCRIPTION
Added an ATC API endpoint for enabling teams via the Fly CLI.

See https://github.com/concourse/concourse/issues/694
