### PR TITLE
Add Prometheus endpoint via metrics emitter

### DIFF
--- a/engine/db_engine.go
+++ b/engine/db_engine.go
@@ -259,6 +259,7 @@ func (build *dbBuild) Resume(logger lager.Logger) {
 		JobName:      build.build.JobName(),
 		BuildName:    build.build.Name(),
 		BuildID:      build.build.ID(),
+		TeamName:     build.build.TeamName(),
 	}.Emit(logger)
 
 	logger.Info("running", lager.Data{
@@ -287,6 +288,7 @@ func (build *dbBuild) Resume(logger lager.Logger) {
 			BuildID:       build.build.ID(),
 			BuildStatus:   build.build.Status(),
 			BuildDuration: build.build.EndTime().Sub(build.build.StartTime()),
+			TeamName:      build.build.TeamName(),
 		}.Emit(logger)
 	}
 }

--- a/metric/emitter/prometheus.go
+++ b/metric/emitter/prometheus.go
@@ -1,0 +1,193 @@
+package emitter
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/atc/db"
+	"github.com/concourse/atc/metric"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type PrometheusEmitter struct {
+	buildsStarted     prometheus.Counter
+	buildsFinished    prometheus.Counter
+	buildsSucceeded   prometheus.Counter
+	buildsErrored     prometheus.Counter
+	buildsFailed      prometheus.Counter
+	buildsAborted     prometheus.Counter
+	buildsFinishedVec *prometheus.CounterVec
+	buildDurationsVec *prometheus.HistogramVec
+}
+
+type PrometheusConfig struct {
+	BindIP   string `long:"prometheus-bind-ip" description:"IP to listen on to expose Prometheus metrics."`
+	BindPort string `long:"prometheus-bind-port" description:"Port to listen on to expose Prometheus metrics."`
+}
+
+func init() {
+	metric.RegisterEmitter(&PrometheusConfig{})
+}
+
+func (config *PrometheusConfig) Description() string { return "Prometheus" }
+func (config *PrometheusConfig) IsConfigured() bool {
+	return config.BindPort != "" && config.BindIP != ""
+}
+func (config *PrometheusConfig) bind() string {
+	return fmt.Sprintf("%s:%s", config.BindIP, config.BindPort)
+}
+
+func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
+	buildsStarted := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "started_total",
+		Help:      "Total number of Concourse builds started.",
+	})
+	prometheus.MustRegister(buildsStarted)
+
+	buildsFinished := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "finished_total",
+		Help:      "Total number of Concourse builds finished.",
+	})
+	prometheus.MustRegister(buildsFinished)
+
+	buildsSucceeded := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "succeeded_total",
+		Help:      "Total number of Concourse builds succeeded.",
+	})
+	prometheus.MustRegister(buildsSucceeded)
+
+	buildsErrored := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "errored_total",
+		Help:      "Total number of Concourse builds errored.",
+	})
+	prometheus.MustRegister(buildsErrored)
+
+	buildsFailed := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "failed_total",
+		Help:      "Total number of Concourse builds failed.",
+	})
+	prometheus.MustRegister(buildsFailed)
+
+	buildsAborted := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "aborted_total",
+		Help:      "Total number of Concourse builds aborted.",
+	})
+	prometheus.MustRegister(buildsAborted)
+
+	buildsFinishedVec := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "concourse",
+			Subsystem: "builds",
+			Name:      "finished",
+			Help:      "Count of builds finished across various dimensions.",
+		},
+		[]string{"team", "pipeline", "status"},
+	)
+	prometheus.MustRegister(buildsFinishedVec)
+	buildDurationsVec := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "concourse",
+			Subsystem: "builds",
+			Name:      "duration_seconds",
+			Help:      "Build time in seconds",
+		},
+		[]string{"team", "pipeline"},
+	)
+	prometheus.MustRegister(buildDurationsVec)
+
+	listener, err := net.Listen("tcp", config.bind())
+	if err != nil {
+		return nil, err
+	}
+
+	go http.Serve(listener, promhttp.Handler())
+
+	return &PrometheusEmitter{
+		buildsStarted:     buildsStarted,
+		buildsFinished:    buildsFinished,
+		buildsFinishedVec: buildsFinishedVec,
+		buildDurationsVec: buildDurationsVec,
+		buildsSucceeded:   buildsSucceeded,
+		buildsErrored:     buildsErrored,
+		buildsFailed:      buildsFailed,
+		buildsAborted:     buildsAborted,
+	}, nil
+}
+
+// Emit processes incoming metrics.
+// In order to provide idiomatic Prometheus metrics, we'll have to convert the various
+// Event types (differentiated by the less-than-ideal string Name field) into different
+// Prometheus metrics.
+func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) {
+	switch event.Name {
+	case "build started":
+		emitter.buildsStarted.Inc()
+	case "build finished":
+		emitter.buildFinishedMetrics(logger, event)
+	default:
+		// unless we have a specific metric, we do nothing
+	}
+}
+
+func (emitter *PrometheusEmitter) buildFinishedMetrics(logger lager.Logger, event metric.Event) {
+	// concourse_builds_finished_total
+	emitter.buildsFinished.Inc()
+
+	// concourse_builds_finished
+	team, exists := event.Attributes["team_name"]
+	if !exists {
+		logger.Error("failed-to-find-team-name-in-event", fmt.Errorf("expected team_name to exist in event.Attributes"))
+	}
+
+	pipeline, exists := event.Attributes["pipeline"]
+	if !exists {
+		logger.Error("failed-to-find-pipeline-in-event", fmt.Errorf("expected pipeline to exist in event.Attributes"))
+	}
+
+	buildStatus, exists := event.Attributes["build_status"]
+	if !exists {
+		logger.Error("failed-to-find-build_status-in-event", fmt.Errorf("expected build_status to exist in event.Attributes"))
+	}
+	emitter.buildsFinishedVec.WithLabelValues(team, pipeline, buildStatus).Inc()
+
+	// concourse_builds_(aborted|succeeded|failed|errored)_total
+	switch buildStatus {
+	case string(db.BuildStatusAborted):
+		// concourse_builds_aborted_total
+		emitter.buildsAborted.Inc()
+	case string(db.BuildStatusSucceeded):
+		// concourse_builds_succeeded_total
+		emitter.buildsSucceeded.Inc()
+	case string(db.BuildStatusFailed):
+		// concourse_builds_failed_total
+		emitter.buildsFailed.Inc()
+	case string(db.BuildStatusErrored):
+		// concourse_builds_errored_total
+		emitter.buildsErrored.Inc()
+	}
+
+	// concourse_builds_duration_seconds
+	duration, ok := event.Value.(float64)
+	if !ok {
+		logger.Error("build-finished-event-value-type-mismatch", fmt.Errorf("expected event.Value to be a float64"))
+	}
+	// seconds are the standard prometheus base unit for time
+	duration = duration / 1000
+	emitter.buildDurationsVec.WithLabelValues(team, pipeline).Observe(duration)
+}

--- a/metric/metrics.go
+++ b/metric/metrics.go
@@ -300,6 +300,7 @@ type BuildStarted struct {
 	JobName      string
 	BuildName    string
 	BuildID      int
+	TeamName     string
 }
 
 func (event BuildStarted) Emit(logger lager.Logger) {
@@ -314,6 +315,7 @@ func (event BuildStarted) Emit(logger lager.Logger) {
 				"job":        event.JobName,
 				"build_name": event.BuildName,
 				"build_id":   strconv.Itoa(event.BuildID),
+				"team_name":  event.TeamName,
 			},
 		},
 	)
@@ -326,6 +328,7 @@ type BuildFinished struct {
 	BuildID       int
 	BuildStatus   db.BuildStatus
 	BuildDuration time.Duration
+	TeamName      string
 }
 
 func (event BuildFinished) Emit(logger lager.Logger) {
@@ -341,6 +344,7 @@ func (event BuildFinished) Emit(logger lager.Logger) {
 				"build_name":   event.BuildName,
 				"build_id":     strconv.Itoa(event.BuildID),
 				"build_status": string(event.BuildStatus),
+				"team_name":    event.TeamName,
 			},
 		},
 	)


### PR DESCRIPTION
Implment a Prometheus metrics emitter that starts
a Prometheus `/metrics` HTTP endpoint.

The emitter pattern is not perfectly suited for idiomatic
Prometheus metrics, as they contain a lot of context that would
translate to labels (and thus time series) in Prometheus, so I've mapped
a couple of the events to specific Prometheus metrics that
will keep a reasonable cardinality as build/pipeline/team volume grows.

I've started by implementing some specific (hopefully useful) metrics
around starting/finishing builds. I imagine future PRs from interested
parties can continue porting the remaining wealth of metrics.

Here is a sample of the metrics implemented:
```
/ HELP concourse_builds_aborted_total Total number of Concourse builds aborted.
/ TYPE concourse_builds_aborted_total counter
concourse_builds_aborted_total 0
/ HELP concourse_builds_duration_seconds Build time in seconds
/ TYPE concourse_builds_duration_seconds summary
concourse_builds_duration_seconds{pipeline="",team="main",quantile="0.5"} 2.649075
concourse_builds_duration_seconds{pipeline="",team="main",quantile="0.9"} 2.649075
concourse_builds_duration_seconds{pipeline="",team="main",quantile="0.99"} 2.649075
concourse_builds_duration_seconds_sum{pipeline="",team="main"} 43.378392000000005
concourse_builds_duration_seconds_count{pipeline="",team="main"} 3
/ HELP concourse_builds_errored_total Total number of Concourse builds errored.
/ TYPE concourse_builds_errored_total counter
concourse_builds_errored_total 1
/ HELP concourse_builds_failed_total Total number of Concourse builds failed.
/ TYPE concourse_builds_failed_total counter
concourse_builds_failed_total 0
/ HELP concourse_builds_finished Count of builds finished across various dimensions.
/ TYPE concourse_builds_finished counter
concourse_builds_finished{pipeline="",status="errored",team="main"} 1
concourse_builds_finished{pipeline="",status="succeeded",team="main"} 2
/ HELP concourse_builds_finished_total Total number of Concourse builds finished.
/ TYPE concourse_builds_finished_total counter
concourse_builds_finished_total 3
/ HELP concourse_builds_started_total Total number of Concourse builds started.
/ TYPE concourse_builds_started_total counter
concourse_builds_started_total 3
/ HELP concourse_builds_succeeded_total Total number of Concourse builds succeeded.
/ TYPE concourse_builds_succeeded_total counter
```

Additionally, I've added the team name to the build started/finished
metrics. This is a useful bit to have, I think. All of our interested
folks would love to be able to slice this info by team.

The current state doesn't vendor the libraries needed in the
`atc/emitter/vendor` directory. I had a bit of trouble with `godep`
I'm hoping someone with a healthier Concourse environment can
help me debug!

I'd still consider the metrics content to be WIP here, I'm totally open
to changing them pending feedback. I know these would be very useful to
us though.