### PR TITLE
Add Param Support to custom resource types (Issue 1690)

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,6 +65,7 @@ type ResourceType struct {
 	Source     Source `yaml:"source" json:"source" mapstructure:"source"`
 	Privileged bool   `yaml:"privileged,omitempty" json:"privileged" mapstructure:"privileged"`
 	Tags       Tags   `yaml:"tags,omitempty" json:"tags" mapstructure:"tags"`
+	Params     Params `yaml:"params,omitempty" json:"params" mapstructure:"params"`
 }
 
 type ResourceTypes []ResourceType

--- a/db/dbfakes/fake_resource_type.go
+++ b/db/dbfakes/fake_resource_type.go
@@ -54,6 +54,15 @@ type FakeResourceType struct {
 	sourceReturnsOnCall map[int]struct {
 		result1 atc.Source
 	}
+	ParamsStub        func() atc.Params
+	paramsMutex       sync.RWMutex
+	paramsArgsForCall []struct{}
+	paramsReturns     struct {
+		result1 atc.Params
+	}
+	paramsReturnsOnCall map[int]struct {
+		result1 atc.Params
+	}
 	SetResourceConfigStub        func(int) error
 	setResourceConfigMutex       sync.RWMutex
 	setResourceConfigArgsForCall []struct {
@@ -297,6 +306,46 @@ func (fake *FakeResourceType) SourceReturnsOnCall(i int, result1 atc.Source) {
 	}
 	fake.sourceReturnsOnCall[i] = struct {
 		result1 atc.Source
+	}{result1}
+}
+
+func (fake *FakeResourceType) Params() atc.Params {
+	fake.paramsMutex.Lock()
+	ret, specificReturn := fake.paramsReturnsOnCall[len(fake.paramsArgsForCall)]
+	fake.paramsArgsForCall = append(fake.paramsArgsForCall, struct{}{})
+	fake.recordInvocation("Params", []interface{}{})
+	fake.paramsMutex.Unlock()
+	if fake.ParamsStub != nil {
+		return fake.ParamsStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.paramsReturns.result1
+}
+
+func (fake *FakeResourceType) ParamsCallCount() int {
+	fake.paramsMutex.RLock()
+	defer fake.paramsMutex.RUnlock()
+	return len(fake.paramsArgsForCall)
+}
+
+func (fake *FakeResourceType) ParamsReturns(result1 atc.Params) {
+	fake.ParamsStub = nil
+	fake.paramsReturns = struct {
+		result1 atc.Params
+	}{result1}
+}
+
+func (fake *FakeResourceType) ParamsReturnsOnCall(i int, result1 atc.Params) {
+	fake.ParamsStub = nil
+	if fake.paramsReturnsOnCall == nil {
+		fake.paramsReturnsOnCall = make(map[int]struct {
+			result1 atc.Params
+		})
+	}
+	fake.paramsReturnsOnCall[i] = struct {
+		result1 atc.Params
 	}{result1}
 }
 

--- a/db/resource_type.go
+++ b/db/resource_type.go
@@ -25,6 +25,7 @@ type ResourceType interface {
 	Type() string
 	Privileged() bool
 	Source() atc.Source
+	Params() atc.Params
 
 	SetResourceConfig(int) error
 
@@ -45,6 +46,7 @@ func (resourceTypes ResourceTypes) Deserialize() atc.VersionedResourceTypes {
 				Name:       t.Name(),
 				Type:       t.Type(),
 				Source:     t.Source(),
+				Params:     t.Params(),
 				Privileged: t.Privileged(),
 			},
 			Version: t.Version(),
@@ -62,6 +64,7 @@ func (resourceTypes ResourceTypes) Configs() atc.ResourceTypes {
 			Name:       r.Name(),
 			Type:       r.Type(),
 			Source:     r.Source(),
+			Params:     r.Params(),
 			Privileged: r.Privileged(),
 		})
 	}
@@ -79,6 +82,7 @@ type resourceType struct {
 	type_      string
 	privileged bool
 	source     atc.Source
+	params     atc.Params
 	version    atc.Version
 
 	conn Conn
@@ -89,6 +93,7 @@ func (t *resourceType) Name() string       { return t.name }
 func (t *resourceType) Type() string       { return t.type_ }
 func (t *resourceType) Privileged() bool   { return t.privileged }
 func (t *resourceType) Source() atc.Source { return t.source }
+func (t *resourceType) Params() atc.Params { return t.params }
 
 func (t *resourceType) Version() atc.Version { return t.version }
 func (t *resourceType) SaveVersion(version atc.Version) error {
@@ -181,6 +186,7 @@ func scanResourceType(t *resourceType, row scannable) error {
 	}
 
 	t.source = config.Source
+	t.params = config.Params
 	t.privileged = config.Privileged
 
 	return nil

--- a/db/resource_type_test.go
+++ b/db/resource_type_test.go
@@ -31,6 +31,12 @@ var _ = Describe("ResourceType", func() {
 						Privileged: true,
 						Source:     atc.Source{"some": "other-repository"},
 					},
+					{
+						Name:   "some-type-with-params",
+						Type:   "s3",
+						Source: atc.Source{"some": "repository"},
+						Params: atc.Params{"unpack": "true"},
+					},
 				},
 			},
 			0,
@@ -50,7 +56,7 @@ var _ = Describe("ResourceType", func() {
 		})
 
 		It("returns the resource types", func() {
-			Expect(resourceTypes).To(HaveLen(2))
+			Expect(resourceTypes).To(HaveLen(3))
 
 			ids := map[int]struct{}{}
 
@@ -69,10 +75,14 @@ var _ = Describe("ResourceType", func() {
 					Expect(t.Source()).To(Equal(atc.Source{"some": "other-repository"}))
 					Expect(t.Version()).To(BeNil())
 					Expect(t.Privileged()).To(BeTrue())
+				case "some-type-with-params":
+					Expect(t.Name()).To(Equal("some-type-with-params"))
+					Expect(t.Type()).To(Equal("s3"))
+					Expect(t.Params()).To(Equal(atc.Params{"unpack": "true"}))
 				}
 			}
 
-			Expect(ids).To(HaveLen(2))
+			Expect(ids).To(HaveLen(3))
 		})
 
 		Context("when a resource type becomes inactive", func() {

--- a/exec/task_action_test.go
+++ b/exec/task_action_test.go
@@ -91,6 +91,7 @@ var _ = Describe("TaskAction", func() {
 					Name:   "custom-resource",
 					Type:   "custom-type",
 					Source: atc.Source{"some-custom": "source"},
+					Params: atc.Params{"some-custom": "param"},
 				},
 				Version: atc.Version{"some-custom": "version"},
 			},

--- a/worker/image/image_factory.go
+++ b/worker/image/image_factory.go
@@ -63,6 +63,7 @@ func (f *imageFactory) GetImage(
 			worker.ImageResource{
 				Type:   resourceType.Type,
 				Source: resourceType.Source,
+				Params: &resourceType.Params,
 			},
 			resourceType.Version,
 			teamID,


### PR DESCRIPTION
Resolves https://github.com/concourse/concourse/issues/1690 by adding `params` support to `resource_types`.

Tests were updated and ensured that all unit tests passed. Would be willing to look into more extensive testing if necessary.