### PR TITLE
[RFC] Add attempts to versioned_resources & endpoint

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -180,6 +180,7 @@ func NewHandler(
 		atc.GetResourceVersion:            pipelineHandlerFactory.HandlerFor(versionServer.GetResourceVersion),
 		atc.EnableResourceVersion:         pipelineHandlerFactory.HandlerFor(versionServer.EnableResourceVersion),
 		atc.DisableResourceVersion:        pipelineHandlerFactory.HandlerFor(versionServer.DisableResourceVersion),
+		atc.ReattemptResourceVersion:      pipelineHandlerFactory.HandlerFor(versionServer.ReattemptResourceVersion),
 		atc.ListBuildsWithVersionAsInput:  pipelineHandlerFactory.HandlerFor(versionServer.ListBuildsWithVersionAsInput),
 		atc.ListBuildsWithVersionAsOutput: pipelineHandlerFactory.HandlerFor(versionServer.ListBuildsWithVersionAsOutput),
 		atc.GetResourceCausality:          pipelineHandlerFactory.HandlerFor(versionServer.GetCausality),

--- a/api/resourceserver/versionserver/reattempt_version.go
+++ b/api/resourceserver/versionserver/reattempt_version.go
@@ -1,0 +1,29 @@
+package versionserver
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/concourse/atc/db"
+	"github.com/tedsuo/rata"
+)
+
+func (s *Server) ReattemptResourceVersion(pipeline db.Pipeline) http.Handler {
+	logger := s.logger.Session("reattempt-resource-version")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		versionedResourceID, err := strconv.Atoi(rata.Param(r, "resource_version_id"))
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		err = pipeline.ReattemptVersionedResource(versionedResourceID)
+		if err != nil {
+			logger.Error("failed-to-reattempt-versioned-resource", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/api/versions_test.go
+++ b/api/versions_test.go
@@ -349,6 +349,9 @@ var _ = Describe("Versions API", func() {
 		})
 	})
 
+	Describe("PUT /api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/reattempt", func() {
+	})
+
 	Describe("GET /api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/input_to", func() {
 		var response *http.Response
 		var stringVersionID string

--- a/db/migrations/183_add_attempts_to_versioned_resources.go
+++ b/db/migrations/183_add_attempts_to_versioned_resources.go
@@ -1,0 +1,27 @@
+package migrations
+
+import "github.com/concourse/atc/db/migration"
+
+func AddAttemptsToVersionedResources(tx migration.LimitedTx) error {
+	_, err := tx.Exec(`
+    ALTER TABLE versioned_resources ADD COLUMN attempts int DEFAULT(0) NOT NULL
+  `)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`
+    CREATE UNIQUE INDEX versioned_resources_resource_id_type_version_attempts
+      ON versioned_resources (resource_id, type, version, attempts)
+  `)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`
+    DROP INDEX versioned_resources_resource_id_type_version
+  `)
+
+	return err
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -199,5 +199,6 @@ func New(strategy EncryptionStrategy) []migration.Migrator {
 		AddFailedStateToVolumes,
 		AddFailedStateToContainers,
 		UseMd5ForResourceCacheVersions,
+		AddAttemptsToVersionedResources,
 	}
 }

--- a/routes.go
+++ b/routes.go
@@ -38,6 +38,7 @@ const (
 	GetResourceVersion            = "GetResourceVersion"
 	EnableResourceVersion         = "EnableResourceVersion"
 	DisableResourceVersion        = "DisableResourceVersion"
+	ReattemptResourceVersion      = "ReattemptResourceVersion"
 	ListBuildsWithVersionAsInput  = "ListBuildsWithVersionAsInput"
 	ListBuildsWithVersionAsOutput = "ListBuildsWithVersionAsOutput"
 	GetResourceCausality          = "GetResourceCausality"
@@ -137,6 +138,7 @@ var Routes = rata.Routes([]rata.Route{
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id", Method: "GET", Name: GetResourceVersion},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/enable", Method: "PUT", Name: EnableResourceVersion},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/disable", Method: "PUT", Name: DisableResourceVersion},
+	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/reattempt", Method: "PUT", Name: ReattemptResourceVersion},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/input_to", Method: "GET", Name: ListBuildsWithVersionAsInput},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/output_of", Method: "GET", Name: ListBuildsWithVersionAsOutput},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/causality", Method: "GET", Name: GetResourceCausality},


### PR DESCRIPTION
This attempts to address point (2) from https://github.com/concourse/concourse/issues/413#issuecomment-233076618

> Retrying a build (this issue): I want to re-run the current build, either to see if it's flaky or to retry because something outside the build failed (e.g. github, a deployment, etc.).

It adds a counter (`attempts`) to the tuple that defines resource versions, so concourse would now control `resource_id`, `type`, and `attempts` and the resource's `check` provides the `version`. (I believe that the existing scheduler will work without changes, however, I had trouble following all of the logic in the scheduler package.) This could later be exposed both in fly (e.g. `fly -t ci reattempt PIPELINE/RESOURCE/ID`  and in the UI via a button similar to the "+" button on the resources page. 

Happy to receive feedback and comments - I believe this address some of the concerns raised in https://github.com/concourse/concourse/issues/413#issuecomment-311399474 about versions in the context of pipelines, but if this isn't the direction concourse is going (e.g. https://github.com/concourse/concourse/issues/1172) happy to close as well. Thanks!
