### PR TITLE
Added ca-cert for generic oauth provider

### DIFF
--- a/auth/file_contents_flag.go
+++ b/auth/file_contents_flag.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+)
+
+type FileContentsFlag string
+
+func (f *FileContentsFlag) UnmarshalFlag(value string) error {
+	if value == "" {
+		return nil
+	}
+
+	matches, err := filepath.Glob(value)
+	if err != nil {
+		return fmt.Errorf("failed to expand path '%s': %s", value, err)
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("path '%s' does not exist", value)
+	}
+
+	if len(matches) > 1 {
+		return fmt.Errorf("path '%s' resolves to multiple entries: %s", value, strings.Join(matches, ", "))
+	}
+
+	cert, err := ioutil.ReadFile(matches[0])
+	if err != nil {
+		return fmt.Errorf("failed to read file from path '%s'", value)
+	}
+
+	*f = FileContentsFlag(cert)
+
+	return nil
+}

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -1,6 +1,8 @@
 package genericoauth
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -25,6 +27,7 @@ const ProviderName = "oauth"
 type Provider struct {
 	verifier.Verifier
 	Config ConfigOverride
+	CACert string
 }
 
 type ConfigOverride struct {
@@ -47,6 +50,7 @@ type GenericOAuthConfig struct {
 	AuthURLParams map[string]string `json:"auth_url_params,omitempty"   long:"auth-url-param"  description:"Parameter to pass to the authentication server AuthURL. Can be specified multiple times."`
 	Scope         string            `json:"scope,omitempty"             long:"scope"           description:"Optional scope required to authorize user"`
 	TokenURL      string            `json:"token_url,omitempty"         long:"token-url"       description:"Generic OAuth provider TokenURL endpoint."`
+	CACert        string            `json:"ca_cert,omitempty"           long:"ca-cert"         description:"PEM-encoded CA certificate string"`
 }
 
 func (config *GenericOAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.AuthMethod {
@@ -154,6 +158,7 @@ func (GenericTeamProvider) ProviderConstructor(
 			},
 			AuthURLParams: genericOAuth.AuthURLParams,
 		},
+	  CACert: string(genericOAuth.CACert),
 	}, true
 }
 
@@ -177,11 +182,25 @@ func (provider Provider) Client(ctx context.Context, t *oauth2.Token) *http.Clie
 	return provider.Config.Client(ctx, t)
 }
 
-func (Provider) PreTokenClient() (*http.Client, error) {
+func (p Provider) PreTokenClient() (*http.Client, error) {
+	transport := &http.Transport{
+		Proxy:             http.ProxyFromEnvironment,
+		DisableKeepAlives: true,
+	}
+
+	if p.CACert != "" {
+		caCertPool := x509.NewCertPool()
+		ok := caCertPool.AppendCertsFromPEM([]byte(p.CACert))
+		if !ok {
+			return nil, errors.New("failed to use cf certificate")
+		}
+
+		transport.TLSClientConfig = &tls.Config{
+			RootCAs: caCertPool,
+		}
+	}
+
 	return &http.Client{
-		Transport: &http.Transport{
-			Proxy:             http.ProxyFromEnvironment,
-			DisableKeepAlives: true,
-		},
+		Transport: transport,
 	}, nil
 }

--- a/auth/genericoauth/provider.go
+++ b/auth/genericoauth/provider.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 
 	"github.com/concourse/atc"
+	"github.com/concourse/atc/auth"
 	"github.com/concourse/atc/auth/provider"
 	"github.com/concourse/atc/auth/routes"
 	"github.com/concourse/atc/auth/verifier"
@@ -50,7 +51,7 @@ type GenericOAuthConfig struct {
 	AuthURLParams map[string]string `json:"auth_url_params,omitempty"   long:"auth-url-param"  description:"Parameter to pass to the authentication server AuthURL. Can be specified multiple times."`
 	Scope         string            `json:"scope,omitempty"             long:"scope"           description:"Optional scope required to authorize user"`
 	TokenURL      string            `json:"token_url,omitempty"         long:"token-url"       description:"Generic OAuth provider TokenURL endpoint."`
-	CACert        string            `json:"ca_cert,omitempty"           long:"ca-cert"         description:"PEM-encoded CA certificate string"`
+	CACert        auth.FileContentsFlag            `json:"ca_cert,omitempty"           long:"ca-cert"         description:"PEM-encoded CA certificate string"`
 }
 
 func (config *GenericOAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.AuthMethod {

--- a/auth/uaa/provider.go
+++ b/auth/uaa/provider.go
@@ -5,14 +5,12 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"path/filepath"
-	"strings"
 
 	"encoding/json"
 
 	"github.com/concourse/atc"
+	"github.com/concourse/atc/auth"
 	"github.com/concourse/atc/auth/provider"
 	"github.com/concourse/atc/auth/routes"
 	"github.com/concourse/atc/auth/verifier"
@@ -50,41 +48,11 @@ type UAAAuthConfig struct {
 	ClientID     string `json:"client_id"     long:"client-id"     description:"Application client ID for enabling UAA OAuth."`
 	ClientSecret string `json:"client_secret" long:"client-secret" description:"Application client secret for enabling UAA OAuth."`
 
-	AuthURL  string           `json:"auth_url,omitempty"      long:"auth-url"      description:"UAA AuthURL endpoint."`
-	TokenURL string           `json:"token_url,omitempty"     long:"token-url"     description:"UAA TokenURL endpoint."`
-	CFSpaces []string         `json:"cf_spaces,omitempty"     long:"cf-space"      description:"Space GUID for a CF space whose developers will have access."`
-	CFURL    string           `json:"cf_url,omitempty"        long:"cf-url"        description:"CF API endpoint."`
-	CFCACert FileContentsFlag `json:"cf_ca_cert,omitempty"    long:"cf-ca-cert"    description:"Path to CF PEM-encoded CA certificate file."`
-}
-
-type FileContentsFlag string
-
-func (f *FileContentsFlag) UnmarshalFlag(value string) error {
-	if value == "" {
-		return nil
-	}
-
-	matches, err := filepath.Glob(value)
-	if err != nil {
-		return fmt.Errorf("failed to expand path '%s': %s", value, err)
-	}
-
-	if len(matches) == 0 {
-		return fmt.Errorf("path '%s' does not exist", value)
-	}
-
-	if len(matches) > 1 {
-		return fmt.Errorf("path '%s' resolves to multiple entries: %s", value, strings.Join(matches, ", "))
-	}
-
-	cert, err := ioutil.ReadFile(matches[0])
-	if err != nil {
-		return fmt.Errorf("failed to read file from path '%s'", value)
-	}
-
-	*f = FileContentsFlag(cert)
-
-	return nil
+	AuthURL  string                `json:"auth_url,omitempty"      long:"auth-url"      description:"UAA AuthURL endpoint."`
+	TokenURL string                `json:"token_url,omitempty"     long:"token-url"     description:"UAA TokenURL endpoint."`
+	CFSpaces []string              `json:"cf_spaces,omitempty"     long:"cf-space"      description:"Space GUID for a CF space whose developers will have access."`
+	CFURL    string                `json:"cf_url,omitempty"        long:"cf-url"        description:"CF API endpoint."`
+	CFCACert auth.FileContentsFlag `json:"cf_ca_cert,omitempty"    long:"cf-ca-cert"    description:"Path to CF PEM-encoded CA certificate file."`
 }
 
 func (*UAAAuthConfig) AuthMethod(oauthBaseURL string, teamName string) atc.AuthMethod {

--- a/auth/uaa/provider_test.go
+++ b/auth/uaa/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/concourse/atc"
+	"github.com/concourse/atc/auth"
 	"github.com/concourse/atc/auth/provider"
 	"github.com/concourse/atc/auth/uaa"
 	. "github.com/onsi/ginkgo"
@@ -19,7 +20,7 @@ var _ = Describe("UAA Provider", func() {
 		uaaProvider     provider.Provider
 		found           bool
 		uaaTeamProvider uaa.UAATeamProvider
-		sslCert         uaa.FileContentsFlag
+		sslCert         auth.FileContentsFlag
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
While I was integrating UAA (without CF) using the generic OAuth provider I was surprised to see there was no way of specifying a CACert. This PR addresses this.