### PR TITLE
Allow tasks to be clickable behind legend

### DIFF
--- a/web/assets/css/production.less
+++ b/web/assets/css/production.less
@@ -292,6 +292,7 @@ li.prep-status {
 }
 
 .legend {
+  pointer-events: none;
   position: absolute;
   bottom: 1em;
   left: 1em;


### PR DESCRIPTION
Apologies if this is contributed incorrectly and/or contentious at all!

Our concourse installation has tasks to be laid out such that the legend sits over the tasks. Since this is a block element at the top, the tasks underneath it cannot be clicked on even if they are in progress.

![image](https://user-images.githubusercontent.com/5053565/33332712-da829bce-d45c-11e7-8a63-b95e2ef4388b.png)

Since the legend does not contain any links or clickable 'calls to action' we can use pointer-events as a quick fix to propagate the click events to the elements below (this works on all browsers except IE10 and below, which will act as before so there's no regression there.)