### PR TITLE
Fix typo in prometheus worker volumes metric.

### DIFF
--- a/metric/emitter/prometheus.go
+++ b/metric/emitter/prometheus.go
@@ -260,12 +260,12 @@ func (emitter *PrometheusEmitter) workerVolumesMetrics(logger lager.Logger, even
 		logger.Error("failed-to-find-worker-in-event", fmt.Errorf("expected worker to exist in event.Attributes"))
 	}
 
-	workers, ok := event.Value.(int)
+	volumes, ok := event.Value.(int)
 	if !ok {
 		logger.Error("worker-volumes-event-value-type-mismatch", fmt.Errorf("expected event.Value to be an int"))
 	}
 
-	emitter.workerContainers.WithLabelValues(worker).Set(float64(workers))
+	emitter.workerVolumes.WithLabelValues(worker).Set(float64(volumes))
 }
 
 func (emitter *PrometheusEmitter) httpResponseTimeMetrics(logger lager.Logger, event metric.Event) {


### PR DESCRIPTION
😓 

After the fix, we get distinct container and volume counts:

```
# HELP concourse_workers_containers Number of containers per worker
# TYPE concourse_workers_containers gauge
concourse_workers_containers{worker="c0bc0727b104"} 1
# HELP concourse_workers_volumes Number of volumes per worker
# TYPE concourse_workers_volumes gauge
concourse_workers_volumes{worker="c0bc0727b104"} 6
```