### PR TITLE
Fix k8s secret resolution logic

### DIFF
--- a/creds/kubernetes/kubernetes.go
+++ b/creds/kubernetes/kubernetes.go
@@ -23,15 +23,15 @@ func (k Kubernetes) Get(varDef template.VariableDefinition) (interface{}, bool, 
 	var pipelineSecretName = k.PipelineName + "." + varDef.Name
 	var secretName = varDef.Name
 
-	secret, found, err := k.findSecret(namespace, pipelineSecretName)
+	secret, err := k.findSecret(namespace, pipelineSecretName)
 
-	if found {
+	if secret != nil {
 		return k.getValueFromSecret(secret)
 	}
 
-	secret, found, err = k.findSecret(namespace, secretName)
+	secret, err = k.findSecret(namespace, secretName)
 
-	if found {
+	if secret != nil {
 		return k.getValueFromSecret(secret)
 	}
 
@@ -40,7 +40,7 @@ func (k Kubernetes) Get(varDef template.VariableDefinition) (interface{}, bool, 
 		"pipelineSecretName": pipelineSecretName,
 		"secretName":         secretName,
 	})
-	return nil, false, nil
+	return nil, false, err
 }
 
 func (k Kubernetes) getValueFromSecret(secret *v1.Secret) (interface{}, bool, error) {
@@ -57,22 +57,22 @@ func (k Kubernetes) getValueFromSecret(secret *v1.Secret) (interface{}, bool, er
 	return evenLessTyped, true, nil
 }
 
-func (k Kubernetes) findSecret(namespace, name string) (*v1.Secret, bool, error) {
+func (k Kubernetes) findSecret(namespace, name string) (*v1.Secret, error) {
 	var secret *v1.Secret
 	var err error
 
 	secret, err = k.Clientset.Core().Secrets(namespace).Get(name, meta_v1.GetOptions{})
 
 	if err != nil && k8s_errors.IsNotFound(err) {
-		return nil, false, nil
+		return nil, nil
 	} else if err != nil {
 		k.logger.Error("k8s-secret-error", err, lager.Data{
 			"namespace": namespace,
 			"name":      name,
 		})
-		return nil, false, err
+		return nil, err
 	} else {
-		return secret, true, err
+		return secret, err
 	}
 }
 


### PR DESCRIPTION
Apparently there's an issue with the current code. If concourse only has access to "$SECRET" secret and not "$PIPELINE.$SECRET", then apiserver will return a 403 which fails fast, not allowing concourse to try the second option.

This PR makes sure that concourse will try both options before failing, also improves logging.