### PR TITLE
prometheus: remove path from http durations metric to prevent cardinality explosions

### DIFF
--- a/metric/emitter/prometheus.go
+++ b/metric/emitter/prometheus.go
@@ -144,7 +144,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Name:      "duration_seconds",
 			Help:      "Response time in seconds",
 		},
-		[]string{"path", "method"},
+		[]string{"method"},
 	)
 	prometheus.MustRegister(httpRequestsDuration)
 
@@ -269,10 +269,6 @@ func (emitter *PrometheusEmitter) workerVolumesMetrics(logger lager.Logger, even
 }
 
 func (emitter *PrometheusEmitter) httpResponseTimeMetrics(logger lager.Logger, event metric.Event) {
-	path, exists := event.Attributes["path"]
-	if !exists {
-		logger.Error("failed-to-find-path-in-event", fmt.Errorf("expected path to exist in event.Attributes"))
-	}
 	method, exists := event.Attributes["method"]
 	if !exists {
 		logger.Error("failed-to-find-method-in-event", fmt.Errorf("expected method to exist in event.Attributes"))
@@ -283,5 +279,5 @@ func (emitter *PrometheusEmitter) httpResponseTimeMetrics(logger lager.Logger, e
 		logger.Error("http-response-time-event-value-type-mismatch", fmt.Errorf("expected event.Value to be a float64"))
 	}
 
-	emitter.httpRequestsDuration.WithLabelValues(path, method).Observe(responseTime / 1000)
+	emitter.httpRequestsDuration.WithLabelValues(method).Observe(responseTime / 1000)
 }


### PR DESCRIPTION
Having a raw path in this metric causes every path that is visited on
concourse to spin up 14 time series, this is a massive amount of
cardinality that isn't particularly useful. You might try and query for
`path=~"/api/v1/builds.*"`, but you would find that will not work well
in Prometheus if you have any real concourse load.

```
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="0.005"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="0.01"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="0.025"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="0.05"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="0.1"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="0.25"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="0.5"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="1"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="2.5"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="5"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="10"} 1
concourse_http_responses_duration_seconds_bucket{method="GET",path="/api/v1/builds/286098/plan",le="+Inf"} 1
concourse_http_responses_duration_seconds_sum{method="GET",path="/api/v1/builds/286098/plan"} 5.1602000000000005e-05
concourse_http_responses_duration_seconds_count{method="GET",path="/api/v1/builds/286098/plan"} 1
```

The "correct" way to do this type of metric sampling in Prometheus is to
instrument your HTTP router with middleware that samples these paths
based on the "routes" you define, so for the above example, it'd be
`/api/v1/builds`.

I've changed it to simply differentiate on the HTTP verb, as this will
still give a reasonable esimation of HTTP response time, but give a bit
of nuance based on requests that change something vs just viewing, so
you might be able to intuit database issues or something.

In the future, we could try and use some sort of smart path-pruning
library (or just enumerate paths we want) to grab them manually. But for
now, we should ensure we don't cause cardinality explosions, as this
does.

cc: @jmcarp 