### PR TITLE
Add Vault Cache and Exponential Backoff for Login

### DIFF
--- a/creds/vault/api_client.go
+++ b/creds/vault/api_client.go
@@ -1,0 +1,111 @@
+package vault
+
+import (
+	"path"
+	"sync/atomic"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+// The APIClient is a SecretReader which maintains an authorized
+// client using the Login and Renew functions.
+type APIClient struct {
+	clientValue *atomic.Value
+	logger      lager.Logger
+	config      AuthConfig
+}
+
+// NewAPIClient with the associated authorization config and underlying vault client.
+func NewAPIClient(logger lager.Logger, client *vaultapi.Client, config AuthConfig) *APIClient {
+	ac := &APIClient{
+		clientValue: &atomic.Value{},
+		logger:      logger,
+		config:      config,
+	}
+	ac.setClient(client)
+	return ac
+}
+
+// Read must be called after a successful login has occurred or an
+// un-authorized client will be used.
+func (ac *APIClient) Read(path string) (*vaultapi.Secret, error) {
+	return ac.client().Logical().Read(path)
+}
+
+func (ac *APIClient) loginParams() map[string]interface{} {
+	loginParams := make(map[string]interface{})
+	for _, param := range ac.config.Params {
+		loginParams[param.Name] = param.Value
+	}
+
+	return loginParams
+}
+
+// Login the APIClient using the credentials passed at
+// construction. Returns a duration after which renew must be called.
+func (ac *APIClient) Login() (time.Duration, error) {
+	// If we are configured with a client token return right away
+	// and trigger a renewal.
+	if ac.config.ClientToken != "" {
+		ac.setClient(clientWithToken(ac.client(), ac.config.ClientToken))
+		return 0, nil
+	}
+
+	logger := ac.logger.Session("login")
+	client := ac.client()
+	secret, err := client.Logical().Write(path.Join("auth", ac.config.Backend, "login"), ac.loginParams())
+	if err != nil {
+		logger.Error("failed", err)
+		return time.Second, err
+	}
+	logger.Info("succeeded", lager.Data{
+		"token-accessor": secret.Auth.Accessor,
+		"lease-duration": secret.Auth.LeaseDuration,
+		"policies":       secret.Auth.Policies,
+	})
+
+	ac.setClient(clientWithToken(client, secret.Auth.ClientToken))
+	return time.Duration(secret.Auth.LeaseDuration) * time.Second, nil
+}
+
+// Renew the APIClient login using the credentials passed at
+// construction. Must be called after a successful login. Returns a
+// duration after which renew must be called again.
+func (ac *APIClient) Renew() (time.Duration, error) {
+	logger := ac.logger.Session("renew")
+	client := ac.client()
+	secret, err := client.Auth().Token().RenewSelf(0)
+	if err != nil {
+		logger.Error("failed", err)
+		return time.Second, err
+	}
+	logger.Info("succeeded", lager.Data{
+		"token-accessor": secret.Auth.Accessor,
+		"lease-duration": secret.Auth.LeaseDuration,
+		"policies":       secret.Auth.Policies,
+	})
+
+	ac.setClient(clientWithToken(client, secret.Auth.ClientToken))
+	return time.Duration(secret.Auth.LeaseDuration) * time.Second, nil
+}
+
+func (ac *APIClient) client() *vaultapi.Client {
+	return ac.clientValue.Load().(*vaultapi.Client)
+}
+
+func (ac *APIClient) setClient(client *vaultapi.Client) {
+	ac.clientValue.Store(client)
+}
+
+func clientWithToken(client *vaultapi.Client, token string) *vaultapi.Client {
+	// TODO: This is dangerous, we are relying on the vault
+	// client being ok with a shallow copy....
+	// but...
+	// the old code worked ;p
+	clientCopy := *client
+	newClient := &clientCopy
+	newClient.SetToken(token)
+	return newClient
+}

--- a/creds/vault/cache.go
+++ b/creds/vault/cache.go
@@ -1,0 +1,118 @@
+package vault
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+type cachedSecret struct {
+	deadline time.Time
+	secret   *vaultapi.Secret
+}
+
+// A Cache caches secrets read from a SecretReader until the lease on
+// the secret expires. Once expired the credential is proactively
+// deleted from cache to maintain a smaller cache footprint.
+type Cache struct {
+	sync.RWMutex
+	cache    map[string]*cachedSecret
+	newItems chan time.Time
+	sr       SecretReader
+	context  context.Context
+}
+
+// TODO: Should a cache have a max size to
+// prevent unbounded growth?
+
+// NewCache using the underlying vault client.
+func NewCache(sr SecretReader) *Cache {
+	c := &Cache{
+		cache:    make(map[string]*cachedSecret),
+		newItems: make(chan time.Time, 100),
+		sr:       sr,
+	}
+	go c.reaperThread()
+	return c
+}
+
+func (c *Cache) reapCache() time.Time {
+	c.Lock()
+	defer c.Unlock()
+
+	var smallestNext time.Time
+	for k, secret := range c.cache {
+		if time.Now().After(secret.deadline) {
+			delete(c.cache, k)
+			continue
+		}
+		if secret.deadline.Before(smallestNext) {
+			smallestNext = secret.deadline
+		}
+	}
+	return smallestNext
+}
+
+func (c *Cache) reaperThread() {
+	sleep := time.NewTimer(1 * time.Second)
+	defer sleep.Stop()
+	var nextWakeup time.Time
+	for {
+		select {
+		case <-sleep.C:
+			nextWakeup = c.reapCache()
+			if !nextWakeup.IsZero() {
+				sleep.Reset(nextWakeup.Sub(time.Now()))
+			}
+		case t := <-c.newItems:
+			if t.Before(nextWakeup) {
+				continue
+			}
+			nextWakeup = t
+			sleep.Reset(t.Sub(time.Now()))
+		}
+	}
+}
+
+// Read a secret from the cache or the underlying client if not
+// present.
+func (c *Cache) Read(path string) (*vaultapi.Secret, error) {
+	// If we have the secret in our cache just return it
+	c.RLock() // don't use defer because we want to agressively release this lock
+	cs, cached := c.cache[path]
+	c.RUnlock()
+
+	if cached && time.Now().Before(cs.deadline) {
+		return cs.secret, nil
+	}
+
+	// Otherwise fetch the secret using the client. Clients are
+	// thread safe for read use.
+	secret, err := c.sr.Read(path)
+	if err != nil || secret == nil {
+		return secret, err
+	}
+
+	// We will renew the item in half the lease duration to resolve an inherent race
+	// in this setup: What if the secret becomes invalid _during_ the build. We don't
+	// want to be issuing secrets that expire in (fex) 100ms.
+	// This is a problem in any implementation, as lease duration could be 1s and the
+	// build will _probably_ take longer  than that.
+	dur := time.Duration(secret.LeaseDuration) * time.Second / 2
+
+	// Store the secret in cache
+	cs = &cachedSecret{
+		deadline: time.Now().Add(dur),
+		secret:   secret,
+	}
+	c.Lock()
+	c.cache[path] = cs
+	c.Unlock()
+
+	// Tell the reaper thread it has new items to cleanup
+	c.newItems <- cs.deadline
+
+	return secret, nil
+}

--- a/creds/vault/cache_test.go
+++ b/creds/vault/cache_test.go
@@ -1,0 +1,84 @@
+package vault
+
+import (
+	"testing"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+type MockSecretReader struct {
+	secrets []*vaultapi.Secret
+	reads   []string
+}
+
+func (msr *MockSecretReader) Read(path string) (*vaultapi.Secret, error) {
+	msr.reads = append(msr.reads, path)
+	s := msr.secrets[0]
+	msr.secrets = msr.secrets[1:]
+	return s, nil
+}
+
+func TestCache(t *testing.T) {
+	secrets := []*vaultapi.Secret{
+		&vaultapi.Secret{
+			RequestID:     "1",
+			LeaseDuration: 1,
+		},
+		&vaultapi.Secret{
+			RequestID:     "1",
+			LeaseDuration: 2,
+		},
+	}
+	msr := &MockSecretReader{
+		secrets: secrets,
+	}
+
+	cache := NewCache(msr)
+	// miss
+	secret, err := cache.Read("path1")
+	if err != nil {
+		t.Error("got error reading valid secret", err)
+	}
+	if secret.RequestID != secrets[0].RequestID {
+		t.Errorf("read secret %s expected %s", secret.RequestID, secrets[0].RequestID)
+	}
+	if len(msr.reads) != 1 && msr.reads[0] != "path1" {
+		t.Errorf("Got reads [%v], expected [\"%s\"]", msr.reads, "path1")
+	}
+
+	// hit
+	secret, err = cache.Read("path1")
+	if err != nil {
+		t.Error("got error reading valid secret from cache", err)
+	}
+	if secret.RequestID != secrets[0].RequestID {
+		t.Errorf("read secret %s expected %s", secret.RequestID, secrets[0].RequestID)
+	}
+	if len(msr.reads) != 1 && msr.reads[0] != "path1" {
+		t.Errorf("Got reads [%v], expected [\"%s\"]", msr.reads, "path1")
+	}
+
+	// reap
+	time.Sleep(time.Duration(secret.LeaseDuration)*time.Second + 100*time.Millisecond)
+
+	// miss
+	secret, err = cache.Read("path1")
+	if err != nil {
+		t.Error("got error reading valid secret from cache", err)
+	}
+	if secret.RequestID != secrets[0].RequestID {
+		t.Errorf("read secret %s expected %s", secret.RequestID, secrets[0].RequestID)
+	}
+	if len(msr.reads) != 2 && msr.reads[0] != "path1" {
+		t.Errorf("Got reads [%v], expected [\"%s\"]", msr.reads, "path1 path1")
+	}
+
+	// reap
+	time.Sleep(time.Duration(secret.LeaseDuration)*time.Second + 100*time.Millisecond)
+	cache.RLock()
+	if len(cache.cache) != 0 {
+		t.Errorf("Expectde cache to be clean after expiration, was %v", cache.cache)
+	}
+	cache.RUnlock()
+}

--- a/creds/vault/manager.go
+++ b/creds/vault/manager.go
@@ -36,10 +36,10 @@ type VaultManager struct {
 type AuthConfig struct {
 	ClientToken string `long:"client-token" description:"Client token for accessing secrets within the Vault server."`
 
-	Backend       string        `long:"auth-backend" description:"Auth backend to use for logging in to Vault."`
-	BackendMaxTTL time.Duration `long:"auth-backend-max-ttl" description:"Time after which to force a re-login. If not set, the token will just be continuously renewed."`
-	RetryMax      time.Duration `long:"retry-max" description:"The maximum time between retries when logging in or re-authing a secret."`
-	RetryInitial  time.Duration `long:"retry-initial" description:"The initial time between retries when logging in or re-authing a secret."`
+	Backend       string        `long:"auth-backend"               description:"Auth backend to use for logging in to Vault."`
+	BackendMaxTTL time.Duration `long:"auth-backend-max-ttl"       description:"Time after which to force a re-login. If not set, the token will just be continuously renewed."`
+	RetryMax      time.Duration `long:"retry-max"     default:"5m" description:"The maximum time between retries when logging in or re-authing a secret."`
+	RetryInitial  time.Duration `long:"retry-initial" default:"1s" description:"The initial time between retries when logging in or re-authing a secret."`
 
 	Params []template.VarKV `long:"auth-param"  description:"Paramter to pass when logging in via the backend. Can be specified multiple times." value-name:"NAME=VALUE"`
 }

--- a/creds/vault/manager.go
+++ b/creds/vault/manager.go
@@ -18,7 +18,8 @@ type VaultManager struct {
 
 	PathPrefix string `long:"path-prefix" default:"/concourse" description:"Path under which to namespace credential lookup."`
 
-	Cache bool `bool:"cache" default:"false" description:"Cache returned secrets for their lease duration in memory"`
+	Cache    bool          `bool:"cache" default:"false" description:"Cache returned secrets for their lease duration in memory"`
+	MaxLease time.Duration `long:"max-lease" description:"If the cache is enabled, and this is set, override secrets lease duration with a maximum value"`
 
 	TLS struct {
 		CACert     string `long:"ca-cert"              description:"Path to a PEM-encoded CA cert file to use to verify the vault server SSL cert."`
@@ -96,7 +97,7 @@ func (manager VaultManager) NewVariablesFactory(logger lager.Logger) (creds.Vari
 	ra := NewReAuther(c, manager.Auth.BackendMaxTTL, manager.Auth.RetryInitial, manager.Auth.RetryMax)
 	var sr SecretReader = c
 	if manager.Cache {
-		sr = NewCache(c)
+		sr = NewCache(c, manager.MaxLease)
 	}
 
 	return NewVaultFactory(sr, ra.LoggedIn(), manager.PathPrefix), nil

--- a/creds/vault/reauther.go
+++ b/creds/vault/reauther.go
@@ -1,0 +1,105 @@
+package vault
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff"
+)
+
+// An Auther is anything which needs to be logged in and then have
+// that login renewed on a regulary basis.
+type Auther interface {
+	Login() (time.Duration, error)
+	Renew() (time.Duration, error)
+}
+
+// The ReAuther runs the authorization loop (login, renew) and retries
+// using a bounded exponential backoff strategy. If maxTTL is set, a
+// new login will be done _regardless_ of the available leaseDuration.
+type ReAuther struct {
+	auther Auther
+	base   time.Duration
+	max    time.Duration
+	maxTTL time.Duration
+
+	loggedIn chan struct{}
+}
+
+// NewReAuther with a retry time and a max retry time.
+func NewReAuther(auther Auther, maxTTL, retry, max time.Duration) *ReAuther {
+	ra := &ReAuther{
+		auther:   auther,
+		base:     retry,
+		max:      max,
+		maxTTL:   maxTTL,
+		loggedIn: make(chan struct{}, 1),
+	}
+	go ra.authLoop()
+	return ra
+}
+
+// LoggedIn will receive a signal after every login. Multiple logins
+// may result in a single signal as this channel is not blocked.
+func (ra *ReAuther) LoggedIn() <-chan struct{} {
+	return ra.loggedIn
+}
+
+// we can't renew a secret that has exceeded it's maxTTL or it's lease
+func (ra *ReAuther) renewable(leaseEnd, tokenEOL time.Time) bool {
+	now := time.Now()
+
+	return !now.After(leaseEnd) && (ra.maxTTL != 0 && !now.After(tokenEOL))
+}
+
+// sleep until the  tokenEOl or half the lease duration
+func (ra *ReAuther) sleep(leaseEnd, tokenEOL time.Time) {
+	if ra.maxTTL != 0 && leaseEnd.After(tokenEOL) {
+		time.Sleep(tokenEOL.Sub(time.Now()))
+	} else {
+		time.Sleep(leaseEnd.Sub(time.Now()) / 2)
+	}
+
+}
+
+func (ra *ReAuther) authLoop() {
+	var tokenEOL, leaseEnd time.Time
+
+	for {
+		exp := backoff.NewExponentialBackOff()
+		exp.MaxElapsedTime = ra.max
+		exp.InitialInterval = ra.base
+		for {
+			lease, err := ra.auther.Login()
+			if err != nil {
+				time.Sleep(exp.NextBackOff())
+				continue
+			}
+
+			exp.Reset()
+			select {
+			case ra.loggedIn <- struct{}{}:
+			default:
+			}
+
+			now := time.Now()
+			tokenEOL = now.Add(ra.maxTTL)
+			leaseEnd = now.Add(lease)
+			ra.sleep(leaseEnd, tokenEOL)
+			break
+		}
+
+		for {
+			if !ra.renewable(leaseEnd, tokenEOL) {
+				break
+			}
+			lease, err := ra.auther.Renew()
+			if err != nil {
+				time.Sleep(exp.NextBackOff())
+				continue
+			}
+			exp.Reset()
+			leaseEnd = time.Now().Add(lease)
+			ra.sleep(leaseEnd, tokenEOL)
+		}
+	}
+}

--- a/creds/vault/reauther_test.go
+++ b/creds/vault/reauther_test.go
@@ -1,0 +1,77 @@
+package vault
+
+import (
+	"testing"
+	"time"
+)
+
+type MockAuther struct {
+	LoggedIn chan bool
+	Renewed  chan bool
+	Delay    time.Duration
+}
+
+func (ma *MockAuther) Login() (time.Duration, error) {
+	ma.LoggedIn <- true
+	return ma.Delay, nil
+}
+func (ma *MockAuther) Renew() (time.Duration, error) {
+	ma.Renewed <- true
+	return ma.Delay, nil
+}
+
+func TestReAuther(t *testing.T) {
+	ma := &MockAuther{
+		LoggedIn: make(chan bool, 1),
+		Renewed:  make(chan bool, 1),
+		Delay:    1 * time.Second,
+	}
+	ra := NewReAuther(ma, 10*time.Second, 1*time.Second, 64*time.Second)
+	select {
+	case <-ra.LoggedIn():
+	case <-time.After(1 * time.Second):
+		t.Fatal("Didn't issue login within timeout")
+	}
+
+	select {
+	case li := <-ma.LoggedIn:
+		if !li {
+			t.Error("Error, should have logged in after loggedin closed")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Didn't issue login within timeout")
+	}
+
+	select {
+	case <-ma.LoggedIn:
+		t.Error("Should not have logged in again")
+	case r := <-ma.Renewed:
+		if !r {
+			t.Error("Error, should have renewed in before the delay")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Didn't issue login within timeout")
+	}
+
+	select {
+	case <-ma.LoggedIn:
+		t.Error("Should not have logged in again")
+	case r := <-ma.Renewed:
+		if !r {
+			t.Error("Error, should have renewed again in before the delay")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Didn't issue login within timeout")
+	}
+
+	select {
+	case <-ma.LoggedIn:
+	case r := <-ma.Renewed:
+		if !r {
+			t.Error("Error, should have logged in again after the maxTTL")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Didn't issue login within timeout")
+	}
+
+}

--- a/creds/vault/vault.go
+++ b/creds/vault/vault.go
@@ -7,8 +7,16 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 )
 
+// A SecretReader reads a vault secret from the given path. It should
+// be thread safe!
+type SecretReader interface {
+	Read(path string) (*vaultapi.Secret, error)
+}
+
+// Vault converts a vault secret to our completely untyped secret
+// data.
 type Vault struct {
-	VaultClient *vaultapi.Logical
+	SecretReader SecretReader
 
 	PathPrefix   string
 	TeamName     string
@@ -52,7 +60,7 @@ func (v Vault) Get(varDef template.VariableDefinition) (interface{}, bool, error
 }
 
 func (v Vault) findSecret(path string) (*vaultapi.Secret, bool, error) {
-	secret, err := v.VaultClient.Read(path)
+	secret, err := v.SecretReader.Read(path)
 	if err != nil {
 		return nil, false, err
 	}

--- a/creds/vault/vault_factory.go
+++ b/creds/vault/vault_factory.go
@@ -1,174 +1,35 @@
 package vault
 
 import (
-	"path"
-	"sync"
-	"time"
-
-	"code.cloudfoundry.org/lager"
-
-	"github.com/cenkalti/backoff"
 	"github.com/concourse/atc/creds"
-	vaultapi "github.com/hashicorp/vault/api"
 )
 
+// The vaultFactory will return a vault implementation of creds.Variables.
 type vaultFactory struct {
-	vaultClient *vaultapi.Client
-
-	prefix string
-
-	token  string
-	tokenL *sync.RWMutex
-
-	loggedIn chan struct{}
+	sr       SecretReader
+	prefix   string
+	loggedIn <-chan struct{}
 }
 
-func NewVaultFactory(logger lager.Logger, client *vaultapi.Client, auth AuthConfig, prefix string) *vaultFactory {
+func NewVaultFactory(sr SecretReader, loggedIn <-chan struct{}, prefix string) *vaultFactory {
 	factory := &vaultFactory{
-		vaultClient: client,
-
-		prefix: prefix,
-
-		tokenL:   new(sync.RWMutex),
-		loggedIn: make(chan struct{}),
+		sr:       sr,
+		prefix:   prefix,
+		loggedIn: loggedIn,
 	}
-
-	go factory.authLoop(logger, auth)
 
 	return factory
 }
 
+// NewVariables will block until the loggedIn channel passed to the
+// constructor signals a successful login.
 func (factory *vaultFactory) NewVariables(teamName string, pipelineName string) creds.Variables {
 	<-factory.loggedIn
 
 	return &Vault{
-		VaultClient: factory.clientWith(factory.currentToken()).Logical(),
-
+		SecretReader: factory.sr,
 		PathPrefix:   factory.prefix,
 		TeamName:     teamName,
 		PipelineName: pipelineName,
 	}
-}
-
-func (factory *vaultFactory) currentToken() string {
-	factory.tokenL.RLock()
-	token := factory.token
-	factory.tokenL.RUnlock()
-	return token
-}
-
-func (factory *vaultFactory) setToken(token string, lease time.Duration) {
-	factory.tokenL.Lock()
-	factory.token = token
-	factory.tokenL.Unlock()
-}
-
-func (factory *vaultFactory) needsLogin(currentToken string, eol time.Time, lease time.Duration) bool {
-	// never logged in
-	if currentToken == "" {
-		return true
-	}
-
-	// no EOL; no max TTL set
-	if eol.IsZero() {
-		return false
-	}
-
-	// we'll reach EOL before next renewal; force login
-	if time.Now().Add(lease).After(eol) {
-		return true
-	}
-
-	return false
-}
-
-func (factory *vaultFactory) authLoop(logger lager.Logger, config AuthConfig) {
-	exp := backoff.NewExponentialBackOff()
-	exp.MaxElapsedTime = 0
-
-	var tokenEOL time.Time
-	var lease time.Duration
-
-	for {
-		currentToken := factory.currentToken()
-
-		logIn := factory.needsLogin(currentToken, tokenEOL, lease)
-
-		var token string
-		var authErr error
-		if logIn {
-			token, lease, authErr = factory.login(logger.Session("login"), config)
-		} else {
-			token, lease, authErr = factory.renew(logger.Session("renew"), currentToken)
-		}
-
-		if authErr != nil {
-			time.Sleep(exp.NextBackOff())
-			continue
-		}
-
-		if token != "" {
-			if logIn && config.BackendMaxTTL > 0 {
-				tokenEOL = time.Now().Add(config.BackendMaxTTL)
-			}
-
-			factory.setToken(token, lease)
-
-			if currentToken == "" {
-				close(factory.loggedIn)
-			}
-		}
-
-		time.Sleep(lease / 2)
-	}
-}
-
-func (factory *vaultFactory) login(logger lager.Logger, config AuthConfig) (string, time.Duration, error) {
-	if config.ClientToken != "" {
-		return config.ClientToken, time.Second, nil
-	}
-
-	backend := config.Backend
-
-	params := map[string]interface{}{}
-	for _, param := range config.Params {
-		params[param.Name] = param.Value
-	}
-
-	secret, err := factory.vaultClient.Logical().Write(path.Join("auth", backend, "login"), params)
-	if err != nil {
-		logger.Error("failed", err)
-		return "", 0, err
-	}
-
-	logger.Info("succeeded", lager.Data{
-		"token-accessor": secret.Auth.Accessor,
-		"lease-duration": secret.Auth.LeaseDuration,
-		"policies":       secret.Auth.Policies,
-	})
-
-	return secret.Auth.ClientToken, time.Duration(secret.Auth.LeaseDuration * int(time.Second)), nil
-}
-
-func (factory *vaultFactory) renew(logger lager.Logger, token string) (string, time.Duration, error) {
-	secret, err := factory.clientWith(token).Auth().Token().RenewSelf(0)
-	if err != nil {
-		logger.Error("failed", err)
-		return "", 0, err
-	}
-
-	logger.Info("succeeded", lager.Data{
-		"token-accessor": secret.Auth.Accessor,
-		"lease-duration": secret.Auth.LeaseDuration,
-		"policies":       secret.Auth.Policies,
-	})
-
-	return secret.Auth.ClientToken, time.Duration(secret.Auth.LeaseDuration * int(time.Second)), nil
-}
-
-func (factory *vaultFactory) clientWith(token string) *vaultapi.Client {
-	clientCopy := *factory.vaultClient
-	vaultClient := &clientCopy
-	vaultClient.SetToken(token)
-	return vaultClient
 }


### PR DESCRIPTION
Add a cache to the Vault credentials manager. The cache is flagable
and defaults to off. The cache uses the vault set lease duration and
re-fetches secrets halfway to the expiration time.

Add an exponential backoff for login and renewal of vault credentials.
This slows down spam to vault in the event of a bad configuration or
during heavy load. This backoff starts at 1 second and max's out at 64
seconds. This is currently not configurable.

As part of the change refactor so to test both the cache and the retry
strategies. Add unit tests to this effect. It also adds more comments
in the code and cleanups up some go naming stuff.

This change has _not_ been tested with a full deployment yet (I think the  PR will do that for me? ;p)

This is needed because if a user configures secrets in to be passed as params to a check resource it
is trivial to inadvertently attack your own secrets infrastructure. 

I considered trying to add a "meta" credentials cache, but I'm not sure that a single caching strategy/manager will be able to correctly abstract all possible credential stores expected caching behaviors. For example k8s already has a  [sophisticated caching mechanism](https://godoc.org/k8s.io/client-go/tools/cache) available in its standard library.