### PR TITLE
remove timeout in db AfterSuite

### DIFF
--- a/db/db_suite_test.go
+++ b/db/db_suite_test.go
@@ -3,7 +3,6 @@ package db_test
 import (
 	"os"
 	"testing"
-	"time"
 
 	"code.cloudfoundry.org/lager/lagertest"
 	sq "github.com/Masterminds/squirrel"
@@ -182,5 +181,5 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	dbProcess.Signal(os.Interrupt)
-	Eventually(dbProcess.Wait(), 10*time.Second).Should(Receive())
+	<-dbProcess.Wait()
 })


### PR DESCRIPTION
postgres can be slow to terminate.

I'd be happy to raise the timeout to 20 or 60 seconds, but @vito [suggested](https://concourseci.slack.com/archives/C1X5A4AJX/p1516055728000020?thread_ts=1516054819.000319&cid=C1X5A4AJX) we just remove it completely.