### PR TITLE
Throw jsonapi 400 instead of empty 500 on resource type not found.

### DIFF
--- a/api/resources_test.go
+++ b/api/resources_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/jsonapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -653,6 +654,17 @@ var _ = Describe("Resources API", func() {
 
 				It("returns 404", func() {
 					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+				})
+			})
+
+			Context("when checking the resource fails with ResourceTypeNotFoundError", func() {
+				BeforeEach(func() {
+					fakeScanner.ScanFromVersionReturns(db.ResourceTypeNotFoundError{Name: "missing-type"})
+				})
+
+				It("returns jsonapi 400", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					Expect(response.Header.Get("Content-Type")).To(Equal(jsonapi.MediaType))
 				})
 			})
 

--- a/api/resourceserver/check.go
+++ b/api/resourceserver/check.go
@@ -62,11 +62,12 @@ func (s *Server) CheckResource(dbPipeline db.Pipeline) http.Handler {
 		case db.ResourceNotFoundError:
 			w.WriteHeader(http.StatusNotFound)
 		case db.ResourceTypeNotFoundError:
-			w.WriteHeader(http.StatusNotFound)
+			w.Header().Set("Content-Type", jsonapi.MediaType)
+			w.WriteHeader(http.StatusBadRequest)
 			jsonapi.MarshalErrors(w, []*jsonapi.ErrorObject{{
 				Title:  "Resource Type Not Found Error",
 				Detail: err.Error(),
-				Status: "404",
+				Status: "400",
 			}})
 		case error:
 			w.WriteHeader(http.StatusInternalServerError)

--- a/api/resourceserver/check.go
+++ b/api/resourceserver/check.go
@@ -8,6 +8,7 @@ import (
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/db"
 	"github.com/concourse/atc/resource"
+	"github.com/google/jsonapi"
 	"github.com/tedsuo/rata"
 )
 
@@ -60,6 +61,13 @@ func (s *Server) CheckResource(dbPipeline db.Pipeline) http.Handler {
 			}
 		case db.ResourceNotFoundError:
 			w.WriteHeader(http.StatusNotFound)
+		case db.ResourceTypeNotFoundError:
+			w.WriteHeader(http.StatusNotFound)
+			jsonapi.MarshalErrors(w, []*jsonapi.ErrorObject{{
+				Title:  "Resource Type Not Found Error",
+				Detail: err.Error(),
+				Status: "404",
+			}})
 		case error:
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))

--- a/db/resource_cache_factory_test.go
+++ b/db/resource_cache_factory_test.go
@@ -247,7 +247,7 @@ var _ = Describe("ResourceCacheFactory", func() {
 				),
 			)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(db.ErrBaseResourceTypeNotFound))
+			Expect(err).To(Equal(db.ResourceTypeNotFoundError{Name: "some-bogus-base-type"}))
 		})
 
 		It("allows a base resource type to be overridden using itself", func() {

--- a/db/resource_config.go
+++ b/db/resource_config.go
@@ -14,7 +14,6 @@ import (
 var ErrResourceConfigAlreadyExists = errors.New("resource config already exists")
 var ErrResourceConfigDisappeared = errors.New("resource config disappeared")
 var ErrResourceConfigParentDisappeared = errors.New("resource config parent disappeared")
-var ErrBaseResourceTypeNotFound = errors.New("base resource type not found")
 
 // ResourceConfig represents a resource type and config source.
 //
@@ -88,7 +87,7 @@ func (resourceConfig ResourceConfig) findOrCreate(logger lager.Logger, tx Tx) (*
 		}
 
 		if !found {
-			return nil, ErrBaseResourceTypeNotFound
+			return nil, ResourceTypeNotFoundError{Name: resourceConfig.CreatedByBaseResourceType.Name}
 		}
 
 		parentID = urc.CreatedByBaseResourceType.ID


### PR DESCRIPTION
Running `check-resource` on a resource with an undefined resource type throws a 500 with an empty response body. This patch throws a 404 with a jsonapi-formatted payload instead. This should make for clearer error messages, and also fixes part of https://github.com/concourse/concourse/issues/1443.

Note: ideally a resource with a missing resource type would fail validation. I'm guessing that hasn't happened because some resource types are globally available.

cc @wjwoodson