### PR TITLE
Add omitempty's to task input/output configs

### DIFF
--- a/task.go
+++ b/task.go
@@ -344,8 +344,8 @@ type TaskRunConfig struct {
 
 type TaskInputConfig struct {
 	Name     string `json:"name" yaml:"name"`
-	Path     string `json:"path,omitempty" yaml:"path"`
-	Optional bool   `json:"optional,omitempty" yaml:"optional"`
+	Path     string `json:"path,omitempty" yaml:"path,omitempty"`
+	Optional bool   `json:"optional,omitempty" yaml:"optional,omitempty"`
 }
 
 func (input TaskInputConfig) resolvePath() string {
@@ -357,7 +357,7 @@ func (input TaskInputConfig) resolvePath() string {
 
 type TaskOutputConfig struct {
 	Name string `json:"name" yaml:"name"`
-	Path string `json:"path,omitempty" yaml:"path"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 }
 
 func (output TaskOutputConfig) resolvePath() string {


### PR DESCRIPTION
Without `omitempty`s, when a pipeline was serialized in for example `fly get-pipeline` or `fly format-pipeline`, paths with an empty string would be added, like:
```
inputs:
- name: pivnet-opsmgr
  path: ""
```
This could be confusing and would also lead to unnecessary warnings in the vscode plugin.

Also added omitempy to the new optional property, so that it doesn't get added when it's not set. 


Previously, after running `fly fp`:
```
inputs:
- name: pivnet-opsmgr
  path: ""
  optional: false
```

with this change, it should be:
```
inputs:
- name: pivnet-opsmgr
```

