### PR TITLE
Readded default namespace as well as functinality to look for multipl…

### DIFF
--- a/creds/kubernetes/kubernetes_factory.go
+++ b/creds/kubernetes/kubernetes_factory.go
@@ -8,16 +8,20 @@ import (
 )
 
 type kubernetesFactory struct {
-	clientset       *kubernetes.Clientset
-	logger          lager.Logger
-	namespacePrefix string
+	clientset        *kubernetes.Clientset
+	logger           lager.Logger
+	namespacePrefix  string
+	defaultNamespace string
+	secretsName      string
 }
 
-func NewKubernetesFactory(logger lager.Logger, clientset *kubernetes.Clientset, namespacePrefix string) *kubernetesFactory {
+func NewKubernetesFactory(logger lager.Logger, clientset *kubernetes.Clientset, namespacePrefix string, defaultNameSpace string, secretsName string) *kubernetesFactory {
 	factory := &kubernetesFactory{
-		clientset:       clientset,
-		logger:          logger,
-		namespacePrefix: namespacePrefix,
+		clientset:        clientset,
+		logger:           logger,
+		namespacePrefix:  namespacePrefix,
+		defaultNamespace: defaultNameSpace,
+		secretsName:      secretsName,
 	}
 
 	return factory
@@ -25,10 +29,12 @@ func NewKubernetesFactory(logger lager.Logger, clientset *kubernetes.Clientset, 
 
 func (factory *kubernetesFactory) NewVariables(teamName string, pipelineName string) creds.Variables {
 	return &Kubernetes{
-		Clientset:       factory.clientset,
-		TeamName:        teamName,
-		PipelineName:    pipelineName,
-		NamespacePrefix: factory.namespacePrefix,
-		logger:          factory.logger,
+		Clientset:        factory.clientset,
+		TeamName:         teamName,
+		PipelineName:     pipelineName,
+		NamespacePrefix:  factory.namespacePrefix,
+		DefaultNamespace: factory.defaultNamespace,
+		SecretsName:      factory.secretsName,
+		logger:           factory.logger,
 	}
 }

--- a/creds/kubernetes/manager.go
+++ b/creds/kubernetes/manager.go
@@ -12,9 +12,11 @@ import (
 )
 
 type KubernetesManager struct {
-	InClusterConfig bool   `long:"in-cluster" description:"Enables the in-cluster client."`
-	ConfigPath      string `long:"config-path" description:"Path to Kubernetes config when running ATC outside Kubernetes."`
-	NamespacePrefix string `long:"namespace-prefix" default:"concourse-" description:"Prefix to use for Kubernetes namespaces under which secrets will be looked up."`
+	InClusterConfig  bool   `long:"in-cluster" description:"Enables the in-cluster client."`
+	ConfigPath       string `long:"config-path" description:"Path to Kubernetes config when running ATC outside Kubernetes."`
+	DefaultNamespace string `long:"default-namespace" description:"Default namespace to look for all secrets in."`
+	SecretsName      string `long:"secrets-name" description:"The secret to look for credentials in"`
+	NamespacePrefix  string `long:"namespace-prefix" default:"concourse-" description:"Prefix to use for Kubernetes namespaces under which secrets will be looked up if not using default namespace."`
 }
 
 func (manager KubernetesManager) IsConfigured() bool {
@@ -51,5 +53,5 @@ func (manager KubernetesManager) NewVariablesFactory(logger lager.Logger) (creds
 		return nil, err
 	}
 
-	return NewKubernetesFactory(logger, clientset, manager.NamespacePrefix), nil
+	return NewKubernetesFactory(logger, clientset, manager.NamespacePrefix, manager.DefaultNamespace, manager.SecretsName), nil
 }


### PR DESCRIPTION
Adds functionality to:
* Be able to have secrets in a namespace named after our liking (by passing the variable `default-namespace` it will then look for secrets in that namespace, instead of forcing the user to have a namespace called `namespacePrefix+teamName`.
* Be able to have all of our credentials stored in one collective secret, or/and one collective secret per pipeline. So by passing in the variable `secrets-name` it will then look for our credentials within that k8s secret as well as within `secrets-name+pipelineName`. This allows us to create one k8s secret which includes all our encrypted credentials instead of having 1 secret for every credential.
* If no `default-namespace` is given, then it will look within `namespacePrefix+teamName` like previously, hence that functionality is not removed.
* If no `secrets-name` is given it will not look for any credentials in such a collective secret, hence the previous functionality still exists if a user elects to implement it that way. I considered removing the previous functionality completely but felt that more flexibility is positive in this case. 
* It will search in the order: pipeline.credName[value] -> credName[value] -> secretsName[credName] -> secretsName-pipeline[credName]

I believe this PR adds more flexibility to the user instead of making k8s secrets function exactly like Vault just because Vault is designed a certain way. Also, not boxing in the user to have to keep specific naming conventions for the namespace. And we should be clear about what a secret is. In K8S a secret is not a single K/V. One secret can contain multiple fields. And we should take advantage of that.
