### PR TITLE
Get builds by team or pipeline

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -84,7 +84,7 @@ func NewHandler(
 	jobServer := jobserver.NewServer(logger, schedulerFactory, externalURL, variablesFactory)
 	resourceServer := resourceserver.NewServer(logger, scannerFactory)
 	versionServer := versionserver.NewServer(logger, externalURL)
-	pipelineServer := pipelineserver.NewServer(logger, dbTeamFactory, dbPipelineFactory, engine)
+	pipelineServer := pipelineserver.NewServer(logger, dbTeamFactory, dbPipelineFactory, externalURL, engine)
 	configServer := configserver.NewServer(logger, dbTeamFactory)
 	workerServer := workerserver.NewServer(logger, dbTeamFactory, dbWorkerFactory, workerProvider)
 	logLevelServer := loglevelserver.NewServer(logger, sink)
@@ -132,6 +132,7 @@ func NewHandler(
 		atc.HidePipeline:        pipelineHandlerFactory.HandlerFor(pipelineServer.HidePipeline),
 		atc.GetVersionsDB:       pipelineHandlerFactory.HandlerFor(pipelineServer.GetVersionsDB),
 		atc.RenamePipeline:      pipelineHandlerFactory.HandlerFor(pipelineServer.RenamePipeline),
+		atc.ListPipelineBuilds:  pipelineHandlerFactory.HandlerFor(pipelineServer.ListPipelineBuilds),
 		atc.CreatePipelineBuild: pipelineHandlerFactory.HandlerFor(pipelineServer.CreateBuild),
 		atc.PipelineBadge:       pipelineHandlerFactory.HandlerFor(pipelineServer.PipelineBadge),
 

--- a/api/handler.go
+++ b/api/handler.go
@@ -91,7 +91,7 @@ func NewHandler(
 	cliServer := cliserver.NewServer(logger, absCLIDownloadsDir)
 	containerServer := containerserver.NewServer(logger, workerClient, variablesFactory, interceptTimeoutFactory)
 	volumesServer := volumeserver.NewServer(logger, volumeFactory)
-	teamServer := teamserver.NewServer(logger, dbTeamFactory)
+	teamServer := teamserver.NewServer(logger, dbTeamFactory, externalURL)
 	infoServer := infoserver.NewServer(logger, version, workerVersion)
 	legacyServer := legacyserver.NewServer(logger)
 
@@ -175,10 +175,11 @@ func NewHandler(
 		atc.LegacyGetAuthToken:    http.HandlerFunc(legacyServer.GetAuthToken),
 		atc.LegacyGetUser:         http.HandlerFunc(legacyServer.GetUser),
 
-		atc.ListTeams:   http.HandlerFunc(teamServer.ListTeams),
-		atc.SetTeam:     http.HandlerFunc(teamServer.SetTeam),
-		atc.RenameTeam:  http.HandlerFunc(teamServer.RenameTeam),
-		atc.DestroyTeam: http.HandlerFunc(teamServer.DestroyTeam),
+		atc.ListTeams:      http.HandlerFunc(teamServer.ListTeams),
+		atc.SetTeam:        http.HandlerFunc(teamServer.SetTeam),
+		atc.RenameTeam:     http.HandlerFunc(teamServer.RenameTeam),
+		atc.DestroyTeam:    http.HandlerFunc(teamServer.DestroyTeam),
+		atc.ListTeamBuilds: http.HandlerFunc(teamServer.ListTeamBuilds),
 	}
 
 	return rata.NewRouter(atc.Routes, wrapper.Wrap(handlers))

--- a/api/pipelineserver/list_builds.go
+++ b/api/pipelineserver/list_builds.go
@@ -1,0 +1,102 @@
+package pipelineserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/concourse/atc"
+	"github.com/concourse/atc/api/present"
+	"github.com/concourse/atc/db"
+)
+
+func (s *Server) ListPipelineBuilds(pipeline db.Pipeline) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var (
+			err        error
+			until      int
+			since      int
+			limit      int
+			builds     []db.Build
+			pagination db.Pagination
+		)
+
+		logger := s.logger.Session("list-pipeline-builds")
+
+		teamName := r.FormValue(":team_name")
+
+		urlUntil := r.FormValue(atc.PaginationQueryUntil)
+		until, _ = strconv.Atoi(urlUntil)
+
+		urlSince := r.FormValue(atc.PaginationQuerySince)
+		since, _ = strconv.Atoi(urlSince)
+
+		urlLimit := r.FormValue(atc.PaginationQueryLimit)
+
+		limit, _ = strconv.Atoi(urlLimit)
+		if limit == 0 {
+			limit = atc.PaginationAPIDefaultLimit
+		}
+
+		page := db.Page{Until: until, Since: since, Limit: limit}
+
+		builds, pagination, err = pipeline.Builds(page)
+		if err != nil {
+			logger.Error("failed-to-get-pipeline-builds", err)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		if pagination.Next != nil {
+			s.addNextLink(w, teamName, pipeline.Name(), *pagination.Next)
+		}
+
+		if pagination.Previous != nil {
+			s.addPreviousLink(w, teamName, pipeline.Name(), *pagination.Previous)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		atc := make([]atc.Build, len(builds))
+		for i := 0; i < len(builds); i++ {
+			build := builds[i]
+			atc[i] = present.Build(build)
+		}
+
+		err = json.NewEncoder(w).Encode(atc)
+		if err != nil {
+			logger.Error("failed-to-encode-builds", err)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+}
+
+func (s *Server) addNextLink(w http.ResponseWriter, teamName, pipelineName string, page db.Page) {
+	w.Header().Add("Link", fmt.Sprintf(
+		`<%s/api/v1/teams/%s/pipelines/%s/builds?%s=%d&%s=%d>; rel="%s"`,
+		s.externalURL,
+		teamName,
+		pipelineName,
+		atc.PaginationQuerySince,
+		page.Since,
+		atc.PaginationQueryLimit,
+		page.Limit,
+		atc.LinkRelNext,
+	))
+}
+
+func (s *Server) addPreviousLink(w http.ResponseWriter, teamName, pipelineName string, page db.Page) {
+	w.Header().Add("Link", fmt.Sprintf(
+		`<%s/api/v1/teams/%s/pipelines/%s/builds?%s=%d&%s=%d>; rel="%s"`,
+		s.externalURL,
+		teamName,
+		pipelineName,
+		atc.PaginationQueryUntil,
+		page.Until,
+		atc.PaginationQueryLimit,
+		page.Limit,
+		atc.LinkRelPrevious,
+	))
+}

--- a/api/pipelineserver/server.go
+++ b/api/pipelineserver/server.go
@@ -13,12 +13,14 @@ type Server struct {
 	rejector        auth.Rejector
 	pipelineFactory db.PipelineFactory
 	engine          engine.Engine
+	externalURL     string
 }
 
 func NewServer(
 	logger lager.Logger,
 	teamFactory db.TeamFactory,
 	pipelineFactory db.PipelineFactory,
+	externalURL string,
 	engine engine.Engine,
 ) *Server {
 	return &Server{
@@ -26,6 +28,7 @@ func NewServer(
 		teamFactory:     teamFactory,
 		rejector:        auth.UnauthorizedRejector{},
 		pipelineFactory: pipelineFactory,
+		externalURL:     externalURL,
 		engine:          engine,
 	}
 }

--- a/api/teams_test.go
+++ b/api/teams_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/api/accessor/accessorfakes"
@@ -616,6 +617,169 @@ var _ = Describe("Teams API", func() {
 			It("returns 401 Unauthorized", func() {
 				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
 				Expect(fakeTeam.RenameCallCount()).To(Equal(0))
+			})
+		})
+	})
+
+	Describe("GET /api/v1/teams/:team_name/builds", func() {
+		var (
+			response    *http.Response
+			queryParams string
+			teamName    string
+		)
+
+		BeforeEach(func() {
+			teamName = "some-team"
+		})
+
+		JustBeforeEach(func() {
+			var err error
+
+			response, err = client.Get(server.URL + "/api/v1/teams/" + teamName + "/builds" + queryParams)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when not authenticated", func() {
+			BeforeEach(func() {
+				fakeaccess.IsAuthenticatedReturns(false)
+				dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+			})
+
+			It("returns 401", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(fakeTeam.BuildsCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when authenticated", func() {
+			BeforeEach(func() {
+				fakeaccess.IsAuthenticatedReturns(true)
+				dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+			})
+
+			Context("when no params are passed", func() {
+				It("does not set defaults for since and until", func() {
+					Expect(fakeTeam.BuildsCallCount()).To(Equal(1))
+
+					page := fakeTeam.BuildsArgsForCall(0)
+					Expect(page).To(Equal(db.Page{
+						Since: 0,
+						Until: 0,
+						Limit: 100,
+					}))
+				})
+			})
+
+			Context("when all the params are passed", func() {
+				BeforeEach(func() {
+					queryParams = "?since=2&until=3&limit=8"
+				})
+
+				It("passes them through", func() {
+					Expect(fakeTeam.BuildsCallCount()).To(Equal(1))
+
+					page := fakeTeam.BuildsArgsForCall(0)
+					Expect(page).To(Equal(db.Page{
+						Since: 2,
+						Until: 3,
+						Limit: 8,
+					}))
+				})
+			})
+
+			Context("when getting the builds succeeds", func() {
+				var returnedBuilds []db.Build
+
+				BeforeEach(func() {
+					queryParams = "?since=5&limit=2"
+
+					build1 := new(dbfakes.FakeBuild)
+					build1.IDReturns(4)
+					build1.NameReturns("2")
+					build1.JobNameReturns("some-job")
+					build1.PipelineNameReturns("some-pipeline")
+					build1.TeamNameReturns("some-team")
+					build1.StatusReturns(db.BuildStatusStarted)
+					build1.StartTimeReturns(time.Unix(1, 0))
+					build1.EndTimeReturns(time.Unix(100, 0))
+
+					build2 := new(dbfakes.FakeBuild)
+					build2.IDReturns(2)
+					build2.NameReturns("1")
+					build2.JobNameReturns("some-job")
+					build2.PipelineNameReturns("some-pipeline")
+					build2.TeamNameReturns("some-team")
+					build2.StatusReturns(db.BuildStatusSucceeded)
+					build2.StartTimeReturns(time.Unix(101, 0))
+					build2.EndTimeReturns(time.Unix(200, 0))
+
+					returnedBuilds = []db.Build{build1, build2}
+					fakeTeam.BuildsReturns(returnedBuilds, db.Pagination{}, nil)
+				})
+
+				It("returns 200 OK", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+				})
+
+				It("returns Content-Type 'application/json'", func() {
+					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+				})
+
+				It("returns the builds", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(body).To(MatchJSON(`[
+					{
+						"id": 4,
+						"name": "2",
+						"job_name": "some-job",
+						"status": "started",
+						"api_url": "/api/v1/builds/4",
+						"pipeline_name":"some-pipeline",
+						"team_name": "some-team",
+						"start_time": 1,
+						"end_time": 100
+					},
+					{
+						"id": 2,
+						"name": "1",
+						"job_name": "some-job",
+						"status": "succeeded",
+						"api_url": "/api/v1/builds/2",
+						"pipeline_name": "some-pipeline",
+						"team_name": "some-team",
+						"start_time": 101,
+						"end_time": 200
+					}
+				]`))
+				})
+
+				Context("when next/previous pages are available", func() {
+					BeforeEach(func() {
+						fakeTeam.BuildsReturns(returnedBuilds, db.Pagination{
+							Previous: &db.Page{Until: 4, Limit: 2},
+							Next:     &db.Page{Since: 2, Limit: 2},
+						}, nil)
+					})
+
+					It("returns Link headers per rfc5988", func() {
+						Expect(response.Header["Link"]).To(ConsistOf([]string{
+							fmt.Sprintf(`<%s/api/v1/teams/some-team/builds?until=4&limit=2>; rel="previous"`, externalURL),
+							fmt.Sprintf(`<%s/api/v1/teams/some-team/builds?since=2&limit=2>; rel="next"`, externalURL),
+						}))
+					})
+				})
+			})
+
+			Context("when getting the build fails", func() {
+				BeforeEach(func() {
+					fakeTeam.BuildsReturns(nil, db.Pagination{}, errors.New("oh no!"))
+				})
+
+				It("returns 404 Not Found", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+				})
 			})
 		})
 	})

--- a/api/teamserver/list_builds.go
+++ b/api/teamserver/list_builds.go
@@ -1,0 +1,108 @@
+package teamserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/concourse/atc"
+	"github.com/concourse/atc/api/present"
+	"github.com/concourse/atc/db"
+)
+
+func (s *Server) ListTeamBuilds(w http.ResponseWriter, r *http.Request) {
+	var (
+		until      int
+		since      int
+		limit      int
+		builds     []db.Build
+		pagination db.Pagination
+	)
+
+	logger := s.logger.Session("list-team-builds")
+
+	teamName := r.FormValue(":team_name")
+
+	urlUntil := r.FormValue(atc.PaginationQueryUntil)
+	until, _ = strconv.Atoi(urlUntil)
+
+	urlSince := r.FormValue(atc.PaginationQuerySince)
+	since, _ = strconv.Atoi(urlSince)
+
+	urlLimit := r.FormValue(atc.PaginationQueryLimit)
+
+	limit, _ = strconv.Atoi(urlLimit)
+	if limit == 0 {
+		limit = atc.PaginationAPIDefaultLimit
+	}
+
+	page := db.Page{Until: until, Since: since, Limit: limit}
+
+	team, found, err := s.teamFactory.FindTeam(teamName)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !found {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	builds, pagination, err = team.Builds(page)
+	if err != nil {
+		logger.Error("failed-to-get-team-builds", err)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if pagination.Next != nil {
+		s.addNextLink(w, teamName, *pagination.Next)
+	}
+
+	if pagination.Previous != nil {
+		s.addPreviousLink(w, teamName, *pagination.Previous)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	atc := make([]atc.Build, len(builds))
+	for i := 0; i < len(builds); i++ {
+		build := builds[i]
+		atc[i] = present.Build(build)
+	}
+
+	err = json.NewEncoder(w).Encode(atc)
+	if err != nil {
+		logger.Error("failed-to-encode-builds", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) addNextLink(w http.ResponseWriter, teamName string, page db.Page) {
+	w.Header().Add("Link", fmt.Sprintf(
+		`<%s/api/v1/teams/%s/builds?%s=%d&%s=%d>; rel="%s"`,
+		s.externalURL,
+		teamName,
+		atc.PaginationQuerySince,
+		page.Since,
+		atc.PaginationQueryLimit,
+		page.Limit,
+		atc.LinkRelNext,
+	))
+}
+
+func (s *Server) addPreviousLink(w http.ResponseWriter, teamName string, page db.Page) {
+	w.Header().Add("Link", fmt.Sprintf(
+		`<%s/api/v1/teams/%s/builds?%s=%d&%s=%d>; rel="%s"`,
+		s.externalURL,
+		teamName,
+		atc.PaginationQueryUntil,
+		page.Until,
+		atc.PaginationQueryLimit,
+		page.Limit,
+		atc.LinkRelPrevious,
+	))
+}

--- a/api/teamserver/server.go
+++ b/api/teamserver/server.go
@@ -8,14 +8,17 @@ import (
 type Server struct {
 	logger      lager.Logger
 	teamFactory db.TeamFactory
+	externalURL string
 }
 
 func NewServer(
 	logger lager.Logger,
 	teamFactory db.TeamFactory,
+	externalURL string,
 ) *Server {
 	return &Server{
 		logger:      logger,
 		teamFactory: teamFactory,
+		externalURL: externalURL,
 	}
 }

--- a/db/dbfakes/fake_pipeline.go
+++ b/db/dbfakes/fake_pipeline.go
@@ -278,6 +278,21 @@ type FakePipeline struct {
 		result1 []db.Build
 		result2 error
 	}
+	BuildsStub        func(page db.Page) ([]db.Build, db.Pagination, error)
+	buildsMutex       sync.RWMutex
+	buildsArgsForCall []struct {
+		page db.Page
+	}
+	buildsReturns struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}
+	buildsReturnsOnCall map[int]struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}
 	DeleteBuildEventsByBuildIDsStub        func(buildIDs []int) error
 	deleteBuildEventsByBuildIDsMutex       sync.RWMutex
 	deleteBuildEventsByBuildIDsArgsForCall []struct {
@@ -1588,6 +1603,60 @@ func (fake *FakePipeline) GetBuildsWithVersionAsOutputReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
+func (fake *FakePipeline) Builds(page db.Page) ([]db.Build, db.Pagination, error) {
+	fake.buildsMutex.Lock()
+	ret, specificReturn := fake.buildsReturnsOnCall[len(fake.buildsArgsForCall)]
+	fake.buildsArgsForCall = append(fake.buildsArgsForCall, struct {
+		page db.Page
+	}{page})
+	fake.recordInvocation("Builds", []interface{}{page})
+	fake.buildsMutex.Unlock()
+	if fake.BuildsStub != nil {
+		return fake.BuildsStub(page)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fake.buildsReturns.result1, fake.buildsReturns.result2, fake.buildsReturns.result3
+}
+
+func (fake *FakePipeline) BuildsCallCount() int {
+	fake.buildsMutex.RLock()
+	defer fake.buildsMutex.RUnlock()
+	return len(fake.buildsArgsForCall)
+}
+
+func (fake *FakePipeline) BuildsArgsForCall(i int) db.Page {
+	fake.buildsMutex.RLock()
+	defer fake.buildsMutex.RUnlock()
+	return fake.buildsArgsForCall[i].page
+}
+
+func (fake *FakePipeline) BuildsReturns(result1 []db.Build, result2 db.Pagination, result3 error) {
+	fake.BuildsStub = nil
+	fake.buildsReturns = struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakePipeline) BuildsReturnsOnCall(i int, result1 []db.Build, result2 db.Pagination, result3 error) {
+	fake.BuildsStub = nil
+	if fake.buildsReturnsOnCall == nil {
+		fake.buildsReturnsOnCall = make(map[int]struct {
+			result1 []db.Build
+			result2 db.Pagination
+			result3 error
+		})
+	}
+	fake.buildsReturnsOnCall[i] = struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakePipeline) DeleteBuildEventsByBuildIDs(buildIDs []int) error {
 	var buildIDsCopy []int
 	if buildIDs != nil {
@@ -2540,6 +2609,8 @@ func (fake *FakePipeline) Invocations() map[string][][]interface{} {
 	defer fake.getBuildsWithVersionAsInputMutex.RUnlock()
 	fake.getBuildsWithVersionAsOutputMutex.RLock()
 	defer fake.getBuildsWithVersionAsOutputMutex.RUnlock()
+	fake.buildsMutex.RLock()
+	defer fake.buildsMutex.RUnlock()
 	fake.deleteBuildEventsByBuildIDsMutex.RLock()
 	defer fake.deleteBuildEventsByBuildIDsMutex.RUnlock()
 	fake.acquireSchedulingLockMutex.RLock()

--- a/db/dbfakes/fake_team.go
+++ b/db/dbfakes/fake_team.go
@@ -172,6 +172,21 @@ type FakeTeam struct {
 		result2 db.Pagination
 		result3 error
 	}
+	BuildsStub        func(page db.Page) ([]db.Build, db.Pagination, error)
+	buildsMutex       sync.RWMutex
+	buildsArgsForCall []struct {
+		page db.Page
+	}
+	buildsReturns struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}
+	buildsReturnsOnCall map[int]struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}
 	SaveWorkerStub        func(atcWorker atc.Worker, ttl time.Duration) (db.Worker, error)
 	saveWorkerMutex       sync.RWMutex
 	saveWorkerArgsForCall []struct {
@@ -970,6 +985,60 @@ func (fake *FakeTeam) PrivateAndPublicBuildsReturnsOnCall(i int, result1 []db.Bu
 	}{result1, result2, result3}
 }
 
+func (fake *FakeTeam) Builds(page db.Page) ([]db.Build, db.Pagination, error) {
+	fake.buildsMutex.Lock()
+	ret, specificReturn := fake.buildsReturnsOnCall[len(fake.buildsArgsForCall)]
+	fake.buildsArgsForCall = append(fake.buildsArgsForCall, struct {
+		page db.Page
+	}{page})
+	fake.recordInvocation("Builds", []interface{}{page})
+	fake.buildsMutex.Unlock()
+	if fake.BuildsStub != nil {
+		return fake.BuildsStub(page)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fake.buildsReturns.result1, fake.buildsReturns.result2, fake.buildsReturns.result3
+}
+
+func (fake *FakeTeam) BuildsCallCount() int {
+	fake.buildsMutex.RLock()
+	defer fake.buildsMutex.RUnlock()
+	return len(fake.buildsArgsForCall)
+}
+
+func (fake *FakeTeam) BuildsArgsForCall(i int) db.Page {
+	fake.buildsMutex.RLock()
+	defer fake.buildsMutex.RUnlock()
+	return fake.buildsArgsForCall[i].page
+}
+
+func (fake *FakeTeam) BuildsReturns(result1 []db.Build, result2 db.Pagination, result3 error) {
+	fake.BuildsStub = nil
+	fake.buildsReturns = struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeTeam) BuildsReturnsOnCall(i int, result1 []db.Build, result2 db.Pagination, result3 error) {
+	fake.BuildsStub = nil
+	if fake.buildsReturnsOnCall == nil {
+		fake.buildsReturnsOnCall = make(map[int]struct {
+			result1 []db.Build
+			result2 db.Pagination
+			result3 error
+		})
+	}
+	fake.buildsReturnsOnCall[i] = struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeTeam) SaveWorker(atcWorker atc.Worker, ttl time.Duration) (db.Worker, error) {
 	fake.saveWorkerMutex.Lock()
 	ret, specificReturn := fake.saveWorkerReturnsOnCall[len(fake.saveWorkerArgsForCall)]
@@ -1573,6 +1642,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.createOneOffBuildMutex.RUnlock()
 	fake.privateAndPublicBuildsMutex.RLock()
 	defer fake.privateAndPublicBuildsMutex.RUnlock()
+	fake.buildsMutex.RLock()
+	defer fake.buildsMutex.RUnlock()
 	fake.saveWorkerMutex.RLock()
 	defer fake.saveWorkerMutex.RUnlock()
 	fake.workersMutex.RLock()

--- a/db/pipeline.go
+++ b/db/pipeline.go
@@ -61,6 +61,7 @@ type Pipeline interface {
 	EnableVersionedResource(versionedResourceID int) error
 	GetBuildsWithVersionAsInput(versionedResourceID int) ([]Build, error)
 	GetBuildsWithVersionAsOutput(versionedResourceID int) ([]Build, error)
+	Builds(page Page) ([]Build, Pagination, error)
 
 	DeleteBuildEventsByBuildIDs(buildIDs []int) error
 
@@ -765,7 +766,10 @@ func (p *pipeline) Resource(name string) (Resource, bool, error) {
 	}
 
 	return resource, true, nil
+}
 
+func (p *pipeline) Builds(page Page) ([]Build, Pagination, error) {
+	return getBuildsWithPagination(buildsQuery.Where(sq.Eq{"b.pipeline_id": p.id}), page, p.conn, p.lockFactory)
 }
 
 func (p *pipeline) Resources() (Resources, error) {

--- a/db/pipeline_test.go
+++ b/db/pipeline_test.go
@@ -2549,4 +2549,39 @@ var _ = Describe("Pipeline", func() {
 			Expect(builds).To(Equal([]db.Build{}))
 		})
 	})
+
+	Describe("Builds", func() {
+		var expectedBuilds []db.Build
+
+		BeforeEach(func() {
+			_, err := team.CreateOneOffBuild()
+			Expect(err).NotTo(HaveOccurred())
+
+			job, found, err := pipeline.Job("job-name")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			build, err := job.CreateBuild()
+			Expect(err).ToNot(HaveOccurred())
+			expectedBuilds = append(expectedBuilds, build)
+
+			secondBuild, err := job.CreateBuild()
+			Expect(err).ToNot(HaveOccurred())
+			expectedBuilds = append(expectedBuilds, secondBuild)
+
+			someOtherJob, found, err := pipeline.Job("some-other-job")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			thirdBuild, err := someOtherJob.CreateBuild()
+			Expect(err).ToNot(HaveOccurred())
+			expectedBuilds = append(expectedBuilds, thirdBuild)
+		})
+
+		It("returns builds for the current pipeline", func() {
+			builds, _, err := pipeline.Builds(db.Page{Limit: 10})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(builds).To(ConsistOf(expectedBuilds))
+		})
+	})
 })

--- a/db/team.go
+++ b/db/team.go
@@ -47,6 +47,7 @@ type Team interface {
 
 	CreateOneOffBuild() (Build, error)
 	PrivateAndPublicBuilds(Page) ([]Build, Pagination, error)
+	Builds(page Page) ([]Build, Pagination, error)
 
 	SaveWorker(atcWorker atc.Worker, ttl time.Duration) (Worker, error)
 	Workers() ([]Worker, error)
@@ -738,6 +739,10 @@ func (t *team) PrivateAndPublicBuilds(page Page) ([]Build, Pagination, error) {
 		Where(sq.Or{sq.Eq{"p.public": true}, sq.Eq{"t.id": t.id}})
 
 	return getBuildsWithPagination(newBuildsQuery, page, t.conn, t.lockFactory)
+}
+
+func (t *team) Builds(page Page) ([]Build, Pagination, error) {
+	return getBuildsWithPagination(buildsQuery.Where(sq.Eq{"t.id": t.id}), page, t.conn, t.lockFactory)
 }
 
 func (t *team) SaveWorker(atcWorker atc.Worker, ttl time.Duration) (Worker, error) {

--- a/routes.go
+++ b/routes.go
@@ -80,10 +80,11 @@ const (
 	LegacyGetAuthToken    = "LegacyGetAuthToken"
 	LegacyGetUser         = "LegacyGetUser"
 
-	ListTeams   = "ListTeams"
-	SetTeam     = "SetTeam"
-	RenameTeam  = "RenameTeam"
-	DestroyTeam = "DestroyTeam"
+	ListTeams      = "ListTeams"
+	SetTeam        = "SetTeam"
+	RenameTeam     = "RenameTeam"
+	DestroyTeam    = "DestroyTeam"
+	ListTeamBuilds = "ListTeamBuilds"
 
 	SendInputToBuildPlan    = "SendInputToBuildPlan"
 	ReadOutputFromBuildPlan = "ReadOutputFromBuildPlan"
@@ -174,4 +175,5 @@ var Routes = rata.Routes([]rata.Route{
 	{Path: "/api/v1/teams/:team_name", Method: "PUT", Name: SetTeam},
 	{Path: "/api/v1/teams/:team_name/rename", Method: "PUT", Name: RenameTeam},
 	{Path: "/api/v1/teams/:team_name", Method: "DELETE", Name: DestroyTeam},
+	{Path: "/api/v1/teams/:team_name/builds", Method: "GET", Name: ListTeamBuilds},
 })

--- a/routes.go
+++ b/routes.go
@@ -52,6 +52,7 @@ const (
 	ExposePipeline      = "ExposePipeline"
 	HidePipeline        = "HidePipeline"
 	RenamePipeline      = "RenamePipeline"
+	ListPipelineBuilds  = "ListPipelineBuilds"
 	CreatePipelineBuild = "CreatePipelineBuild"
 	PipelineBadge       = "PipelineBadge"
 
@@ -126,6 +127,7 @@ var Routes = rata.Routes([]rata.Route{
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/hide", Method: "PUT", Name: HidePipeline},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/versions-db", Method: "GET", Name: GetVersionsDB},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/rename", Method: "PUT", Name: RenamePipeline},
+	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/builds", Method: "GET", Name: ListPipelineBuilds},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/builds", Method: "POST", Name: CreatePipelineBuild},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/badge", Method: "GET", Name: PipelineBadge},
 

--- a/wrappa/api_auth_wrappa.go
+++ b/wrappa/api_auth_wrappa.go
@@ -100,6 +100,7 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.HeartbeatWorker,
 			atc.DeleteWorker,
 			atc.SetTeam,
+			atc.ListTeamBuilds,
 			atc.RenameTeam,
 			atc.DestroyTeam,
 			atc.ListVolumes:

--- a/wrappa/api_auth_wrappa.go
+++ b/wrappa/api_auth_wrappa.go
@@ -80,6 +80,7 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.ListJobs,
 			atc.GetJob,
 			atc.ListJobBuilds,
+			atc.ListPipelineBuilds,
 			atc.GetResource,
 			atc.ListBuildsWithVersionAsInput,
 			atc.ListBuildsWithVersionAsOutput,

--- a/wrappa/api_auth_wrappa_test.go
+++ b/wrappa/api_auth_wrappa_test.go
@@ -195,6 +195,7 @@ var _ = Describe("APIAuthWrappa", func() {
 				atc.HijackContainer: authenticated(inputHandlers[atc.HijackContainer]),
 				atc.ListContainers:  authenticated(inputHandlers[atc.ListContainers]),
 				atc.ListVolumes:     authenticated(inputHandlers[atc.ListVolumes]),
+				atc.ListTeamBuilds:  authenticated(inputHandlers[atc.ListTeamBuilds]),
 				atc.ListWorkers:     authenticated(inputHandlers[atc.ListWorkers]),
 				atc.RegisterWorker:  authenticated(inputHandlers[atc.RegisterWorker]),
 				atc.HeartbeatWorker: authenticated(inputHandlers[atc.HeartbeatWorker]),

--- a/wrappa/api_auth_wrappa_test.go
+++ b/wrappa/api_auth_wrappa_test.go
@@ -180,6 +180,7 @@ var _ = Describe("APIAuthWrappa", func() {
 				atc.ListJobs:                      openForPublicPipelineOrAuthorized(inputHandlers[atc.ListJobs]),
 				atc.GetJob:                        openForPublicPipelineOrAuthorized(inputHandlers[atc.GetJob]),
 				atc.ListJobBuilds:                 openForPublicPipelineOrAuthorized(inputHandlers[atc.ListJobBuilds]),
+				atc.ListPipelineBuilds:            openForPublicPipelineOrAuthorized(inputHandlers[atc.ListPipelineBuilds]),
 				atc.GetResource:                   openForPublicPipelineOrAuthorized(inputHandlers[atc.GetResource]),
 				atc.ListBuildsWithVersionAsInput:  openForPublicPipelineOrAuthorized(inputHandlers[atc.ListBuildsWithVersionAsInput]),
 				atc.ListBuildsWithVersionAsOutput: openForPublicPipelineOrAuthorized(inputHandlers[atc.ListBuildsWithVersionAsOutput]),


### PR DESCRIPTION
This adds the endpoints needed in order for `fly builds` to request builds by pipeline or team, as discussed in concourse/concourse#2013

Meant to be merged at the same time as related PRs to fly and go-concourse:
https://github.com/concourse/go-concourse/pull/9
https://github.com/concourse/fly/pull/212