### PR TITLE
Fix Vault token max_ttl renewal issue for auth backends

### DIFF
--- a/creds/vault/manager.go
+++ b/creds/vault/manager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 
@@ -32,8 +33,9 @@ type VaultManager struct {
 type AuthConfig struct {
 	ClientToken string `long:"client-token" description:"Client token for accessing secrets within the Vault server."`
 
-	Backend string           `long:"auth-backend" description:"Auth backend to use for logging in to Vault."`
-	Params  []template.VarKV `long:"auth-param"  description:"Paramter to pass when logging in via the backend. Can be specified multiple times." value-name:"NAME=VALUE"`
+	Backend       string           `long:"auth-backend" description:"Auth backend to use for logging in to Vault."`
+	BackendMaxTTL time.Duration    `long:"auth-backend-max-ttl" description:"Auth backend max ttl configuration for token renewal"`
+	Params        []template.VarKV `long:"auth-param"  description:"Paramter to pass when logging in via the backend. Can be specified multiple times." value-name:"NAME=VALUE"`
 }
 
 func (manager VaultManager) IsConfigured() bool {


### PR DESCRIPTION
This is a fix for https://github.com/concourse/concourse/issues/1985 that I've been experiencing on my setup as well. 

### Issue
Vault auth backends like approle have max_ttl options to enforce token rotation. A token can renew itself for a new lease and new TTL, but once the max_ttl of the auth backend is reached the client needs to re-login.

ATC authentication with a Vault configured with a max_ttl will work for the first login and renewal until the max_ttl reached, then it will keep trying to renew the token instead of re-login.

### Solution
Since the max_ttl is on the backend side and a lookup-self by the vault token will show only the ttl (lease) atc needs a new optional flag/env variable to provide that information.

Once the lease comes down and we know that it cannot be renewed more than once we re-login.

A quirk of this solution, if we have a max_ttl of _n_  and a default ttl greater than _n/2_ we will never renew tokens but instead every TTL time re-login and get a new token.

I don't know how the impact of fixing that bug and  https://github.com/concourse/atc/pull/236 that's been pending for a while. 