### PR TITLE
SQL script mistakenly assumes "public" schema

### DIFF
--- a/db/migration/migrations/1517330648_add_worker_resource_certs.up.sql
+++ b/db/migration/migrations/1517330648_add_worker_resource_certs.up.sql
@@ -5,7 +5,7 @@ BEGIN;
       "worker_name" text,
       "certs_path" text,
       PRIMARY KEY ("id"),
-      CONSTRAINT "worker_resource_certs_worker_name_fkey" FOREIGN KEY ("worker_name") REFERENCES "public"."workers"("name") ON DELETE CASCADE ON UPDATE SET NULL
+      CONSTRAINT "worker_resource_certs_worker_name_fkey" FOREIGN KEY ("worker_name") REFERENCES "workers"("name") ON DELETE CASCADE ON UPDATE SET NULL
   );
   ALTER TABLE "volumes"
   ADD COLUMN "worker_resource_certs_id" integer,


### PR DESCRIPTION
Line 8 of 1517330648_add_worker_resource_certs.up.sql assumed that the "workers" table is in the "public" schema. Nothing else makes that assumption and we've always used a different schema name. Fixes Issue https://github.com/concourse/concourse/issues/2120