### PR TITLE
Add BuildLogRetentionCalculator

### DIFF
--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -153,6 +153,9 @@ type ATCCommand struct {
 	BuildTrackerInterval time.Duration `long:"build-tracker-interval" default:"10s" description:"Interval on which to run build tracking."`
 
 	TelemetryOptIn bool `long:"telemetry-opt-in" hidden:"true" description:"Enable anonymous concourse version reporting."`
+
+	DefaultBuildLogsToRetain uint64 `long:"default-build-logs-to-retain" description:"Default build logs to retain, 0 means all"`
+	MaxBuildLogsToRetain     uint64 `long:"max-build-logs-to-retain" description:"Maximum build logs to retain, 0 means not specified. Will override values configured in jobs"`
 }
 
 type Migration struct {
@@ -667,6 +670,10 @@ func (cmd *ATCCommand) constructMembers(
 				logger.Session("build-reaper"),
 				dbPipelineFactory,
 				500,
+				gc.NewBuildLogRetentionCalculator(
+					cmd.DefaultBuildLogsToRetain,
+					cmd.MaxBuildLogsToRetain,
+				),
 			),
 			"build-reaper",
 			lockFactory,

--- a/gc/buildlogretentioncalculator.go
+++ b/gc/buildlogretentioncalculator.go
@@ -1,0 +1,45 @@
+package gc
+
+import "github.com/concourse/atc/db"
+
+type BuildLogRetentionCalculator interface {
+	BuildLogsToRetain(db.Job) int
+}
+
+type buildLogRetentionCalculator struct {
+	defaultBuildLogsToRetain uint64
+	maxBuildLogsToRetain     uint64
+}
+
+func NewBuildLogRetentionCalculator(
+	defaultBuildLogsToRetain uint64,
+	maxBuildLogsToRetain uint64,
+) BuildLogRetentionCalculator {
+	return &buildLogRetentionCalculator{
+		defaultBuildLogsToRetain: defaultBuildLogsToRetain,
+		maxBuildLogsToRetain:     maxBuildLogsToRetain,
+	}
+}
+
+func (blrc *buildLogRetentionCalculator) BuildLogsToRetain(job db.Job) int {
+	// What does the job want?
+	buildLogsToRetain := job.Config().BuildLogsToRetain
+
+	// If not specified, set to default
+	if buildLogsToRetain == 0 {
+		buildLogsToRetain = int(blrc.defaultBuildLogsToRetain)
+	}
+
+	// If we don't have a max set, then we're done
+	if blrc.maxBuildLogsToRetain == 0 {
+		return buildLogsToRetain
+	}
+
+	// If we have a value set, and we're less than the max, then return
+	if buildLogsToRetain > 0 || buildLogsToRetain < int(blrc.maxBuildLogsToRetain) {
+		return buildLogsToRetain
+	}
+
+	// Else, return the max
+	return int(blrc.maxBuildLogsToRetain)
+}

--- a/gc/buildlogretentioncalculator.go
+++ b/gc/buildlogretentioncalculator.go
@@ -1,6 +1,8 @@
 package gc
 
-import "github.com/concourse/atc/db"
+import (
+	"github.com/concourse/atc/db"
+)
 
 type BuildLogRetentionCalculator interface {
 	BuildLogsToRetain(db.Job) int
@@ -36,7 +38,7 @@ func (blrc *buildLogRetentionCalculator) BuildLogsToRetain(job db.Job) int {
 	}
 
 	// If we have a value set, and we're less than the max, then return
-	if buildLogsToRetain > 0 || buildLogsToRetain < int(blrc.maxBuildLogsToRetain) {
+	if buildLogsToRetain > 0 && buildLogsToRetain < int(blrc.maxBuildLogsToRetain) {
 		return buildLogsToRetain
 	}
 

--- a/gc/buildlogretentioncalculator_test.go
+++ b/gc/buildlogretentioncalculator_test.go
@@ -1,0 +1,40 @@
+package gc_test
+
+import (
+	"github.com/concourse/atc"
+	"github.com/concourse/atc/db"
+	"github.com/concourse/atc/db/dbfakes"
+	. "github.com/concourse/atc/gc"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BuildLogRetentionCalculator", func() {
+	It("nothing set gives all", func() {
+		Expect(NewBuildLogRetentionCalculator(0, 0).BuildLogsToRetain(makeJob(0))).To(Equal(0))
+	})
+	It("nothing set but job gives job", func() {
+		Expect(NewBuildLogRetentionCalculator(0, 0).BuildLogsToRetain(makeJob(3))).To(Equal(3))
+	})
+	It("default set gives default", func() {
+		Expect(NewBuildLogRetentionCalculator(5, 0).BuildLogsToRetain(makeJob(0))).To(Equal(5))
+	})
+	It("default and job set gives job", func() {
+		Expect(NewBuildLogRetentionCalculator(5, 0).BuildLogsToRetain(makeJob(6))).To(Equal(6))
+	})
+	It("default and job set and max set gives max if lower", func() {
+		Expect(NewBuildLogRetentionCalculator(5, 4).BuildLogsToRetain(makeJob(6))).To(Equal(4))
+	})
+	It("max only set gives max", func() {
+		Expect(NewBuildLogRetentionCalculator(0, 4).BuildLogsToRetain(makeJob(0))).To(Equal(4))
+	})
+})
+
+func makeJob(retainAmount int) db.Job {
+	rv := new(dbfakes.FakeJob)
+	rv.ConfigReturns(atc.JobConfig{
+		BuildLogsToRetain: retainAmount,
+	})
+	return rv
+}

--- a/gc/buildreaper_test.go
+++ b/gc/buildreaper_test.go
@@ -32,6 +32,7 @@ var _ = Describe("BuildReaper", func() {
 			buildReaperLogger,
 			fakePipelineFactory,
 			batchSize,
+			NewBuildLogRetentionCalculator(0, 0),
 		)
 	})
 

--- a/gc/buildreaper_test.go
+++ b/gc/buildreaper_test.go
@@ -19,11 +19,13 @@ var _ = Describe("BuildReaper", func() {
 		buildReaper         BuildReaper
 		fakePipelineFactory *dbfakes.FakePipelineFactory
 		batchSize           int
+		buildLogRetainCalc  BuildLogRetentionCalculator
 	)
 
 	BeforeEach(func() {
 		fakePipelineFactory = new(dbfakes.FakePipelineFactory)
 		batchSize = 5
+		buildLogRetainCalc = NewBuildLogRetentionCalculator(0, 0)
 	})
 
 	JustBeforeEach(func() {
@@ -32,7 +34,7 @@ var _ = Describe("BuildReaper", func() {
 			buildReaperLogger,
 			fakePipelineFactory,
 			batchSize,
-			NewBuildLogRetentionCalculator(0, 0),
+			buildLogRetainCalc,
 		)
 	})
 
@@ -309,6 +311,34 @@ var _ = Describe("BuildReaper", func() {
 				})
 
 				fakePipeline.JobsReturns([]db.Job{fakeJob}, nil)
+			})
+
+			Context("when we install a custom build log retention calculator", func() {
+				BeforeEach(func() {
+					buildLogRetainCalc = NewBuildLogRetentionCalculator(3, 3)
+
+					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
+						if page == (db.Page{Since: 2, Limit: 1}) {
+							return []db.Build{sb(1)}, db.Pagination{}, nil
+						} else if page == (db.Page{Until: 1, Limit: 4}) {
+							return []db.Build{sb(5), sb(4), sb(3), sb(2)}, db.Pagination{}, nil
+						} else if page == (db.Page{Limit: 3}) {
+							return []db.Build{sb(5), sb(4), sb(3)}, db.Pagination{}, nil
+						} else {
+							Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
+						}
+						return nil, db.Pagination{}, nil
+					}
+
+					fakePipeline.DeleteBuildEventsByBuildIDsReturns(nil)
+					fakeJob.UpdateFirstLoggedBuildIDReturns(nil)
+				})
+
+				It("uses build log calculator", func() {
+					Expect(buildReaper.Run()).NotTo(HaveOccurred())
+					Expect(fakePipeline.DeleteBuildEventsByBuildIDsCallCount()).To(Equal(1))
+					Expect(fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)).To(ConsistOf(1, 2))
+				})
 			})
 
 			Context("when a build of this job has build id 1", func() {


### PR DESCRIPTION
Add `--default-build-logs-to-retain NN` and `--max-build-logs-to-retain NN` options to `atc` to specify a default and maximum number of build logs to retain.

The default is ignored if specified by a job, and the maximum (if specified) is always applied to cap the number of build logs retained.

Both default to `0`, which should have no effect on existing installations.

Addresses https://github.com/concourse/concourse/issues/1417

If this PR is accepted, I'll write another to add to the `bosh` job spec for `atc`.