### PR TITLE
Add missing timestamps to task build events

### DIFF
--- a/engine/task_delegate.go
+++ b/engine/task_delegate.go
@@ -33,6 +33,7 @@ func NewTaskDelegate(build db.Build, planID atc.PlanID, clock clock.Clock) exec.
 func (d *taskDelegate) Initializing(logger lager.Logger, taskConfig atc.TaskConfig) {
 	err := d.build.SaveEvent(event.InitializeTask{
 		Origin:     d.eventOrigin,
+		Time:       time.Now().Unix(),
 		TaskConfig: event.ShadowTaskConfig(taskConfig),
 	})
 	if err != nil {
@@ -46,6 +47,7 @@ func (d *taskDelegate) Initializing(logger lager.Logger, taskConfig atc.TaskConf
 func (d *taskDelegate) Starting(logger lager.Logger, taskConfig atc.TaskConfig) {
 	err := d.build.SaveEvent(event.StartTask{
 		Origin:     d.eventOrigin,
+		Time:       time.Now().Unix(),
 		TaskConfig: event.ShadowTaskConfig(taskConfig),
 	})
 	if err != nil {

--- a/event/events.go
+++ b/event/events.go
@@ -20,6 +20,7 @@ func (FinishTask) EventType() atc.EventType  { return EventTypeFinishTask }
 func (FinishTask) Version() atc.EventVersion { return "4.0" }
 
 type InitializeTask struct {
+	Time       int64      `json:"time"`
 	Origin     Origin     `json:"origin"`
 	TaskConfig TaskConfig `json:"config"`
 }


### PR DESCRIPTION
The `start-task` event already has a time field, but it is not set when
the event is saved the the DB. The `initialize-task` event is completely
missing the field.