### PR TITLE
Credentials provider based on the newly announced AWS SecretsManager

### DIFF
--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -72,6 +72,7 @@ import (
 	// dynamically registered credential managers
 	_ "github.com/concourse/atc/creds/credhub"
 	_ "github.com/concourse/atc/creds/kubernetes"
+	_ "github.com/concourse/atc/creds/secretsmanager"
 	_ "github.com/concourse/atc/creds/ssm"
 	_ "github.com/concourse/atc/creds/vault"
 )

--- a/creds/secretsmanager/manager.go
+++ b/creds/secretsmanager/manager.go
@@ -1,0 +1,109 @@
+package secretsmanager
+
+import (
+	"errors"
+	"io/ioutil"
+	"text/template"
+	"text/template/parse"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/concourse/atc/creds"
+)
+
+const DefaultPipelineSecretTemplate = "/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"
+const DefaultTeamSecretTemplate = "/concourse/{{.Team}}/{{.Secret}}"
+
+type Manager struct {
+	AwsAccessKeyID         string `long:"access-key" description:"AWS Access key ID"`
+	AwsSecretAccessKey     string `long:"secret-key" description:"AWS Secret Access Key"`
+	AwsSessionToken        string `long:"session-token" description:"AWS Session Token"`
+	AwsRegion              string `long:"region" description:"AWS region to send requests to" env:"AWS_REGION"`
+	PipelineSecretTemplate string `long:"pipeline-secret-template" description:"AWS Manager secret identifier template used for pipeline specific parameter" default:"/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"`
+	TeamSecretTemplate     string `long:"team-secret-template" description:"AWS SSM Manager secret identifier  template used for team specific parameter" default:"/concourse/{{.Team}}/{{.Secret}}"`
+}
+
+type Secret struct {
+	Team     string
+	Pipeline string
+	Secret   string
+}
+
+func buildSecretTemplate(name, tmpl string) (*template.Template, error) {
+	t, err := template.New(name).Option("missingkey=error").Parse(tmpl)
+	if err != nil {
+		return nil, err
+	}
+	if parse.IsEmptyTree(t.Root) {
+		return nil, errors.New("secret template should not be empty")
+	}
+	return t, nil
+}
+
+func (manager Manager) IsConfigured() bool {
+	return manager.AwsRegion != ""
+}
+
+func (manager Manager) Validate() error {
+	// Make sure that the template is valid
+	pipelineSecretTemplate, err := buildSecretTemplate("pipeline-secret-template", manager.PipelineSecretTemplate)
+	if err != nil {
+		return err
+	}
+	teamSecretTemplate, err := buildSecretTemplate("team-secret-template", manager.TeamSecretTemplate)
+	if err != nil {
+		return err
+	}
+
+	// Execute the templates on dummy data to verify that it does not expect additional data
+	dummy := Secret{Team: "team", Pipeline: "pipeline", Secret: "secret"}
+	if err = pipelineSecretTemplate.Execute(ioutil.Discard, &dummy); err != nil {
+		return err
+	}
+	if err = teamSecretTemplate.Execute(ioutil.Discard, &dummy); err != nil {
+		return err
+	}
+
+	// All of the AWS credential variables may be empty since credentials may be obtained via environemnt variables
+	// or other means. However, if one of them is provided, then all of them (except session token) must be provided.
+	if manager.AwsAccessKeyID == "" && manager.AwsSecretAccessKey == "" && manager.AwsSessionToken == "" {
+		return nil
+	}
+
+	if manager.AwsAccessKeyID == "" {
+		return errors.New("must provide aws access key id")
+	}
+
+	if manager.AwsSecretAccessKey == "" {
+		return errors.New("must provide aws secret access key")
+	}
+
+	return nil
+}
+
+func (manager Manager) NewVariablesFactory(log lager.Logger) (creds.VariablesFactory, error) {
+	config := &aws.Config{Region: &manager.AwsRegion}
+	if manager.AwsAccessKeyID != "" {
+		config.Credentials = credentials.NewStaticCredentials(manager.AwsAccessKeyID, manager.AwsSecretAccessKey, manager.AwsSessionToken)
+	}
+
+	sess, err := session.NewSession(config)
+	if err != nil {
+		log.Error("create-aws-session", err)
+		return nil, err
+	}
+
+	pipelineSecretTemplate, err := buildSecretTemplate("pipeline-secret-template", manager.PipelineSecretTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	teamSecretTemplate, err := buildSecretTemplate("team-secret-template", manager.TeamSecretTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSecretsManagerFactory(log, sess, []*template.Template{pipelineSecretTemplate, teamSecretTemplate}), nil
+}

--- a/creds/secretsmanager/manager_factory.go
+++ b/creds/secretsmanager/manager_factory.go
@@ -1,0 +1,26 @@
+package secretsmanager
+
+import (
+	"github.com/concourse/atc/creds"
+	flags "github.com/jessevdk/go-flags"
+)
+
+type managerFactory struct{}
+
+func init() {
+	creds.Register("secretsmanager", NewManagerFactory())
+}
+
+func NewManagerFactory() creds.ManagerFactory {
+	return &managerFactory{}
+}
+
+func (factory *managerFactory) AddConfig(group *flags.Group) creds.Manager {
+	manager := &Manager{}
+	subGroup, err := group.AddGroup("AWS SecretsManager Credential Management", "", manager)
+	if err != nil {
+		panic(err)
+	}
+	subGroup.Namespace = "aws-secretsmanager"
+	return manager
+}

--- a/creds/secretsmanager/manager_test.go
+++ b/creds/secretsmanager/manager_test.go
@@ -1,0 +1,109 @@
+package secretsmanager_test
+
+import (
+	"github.com/concourse/atc/creds/secretsmanager"
+	"github.com/jessevdk/go-flags"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Manager", func() {
+	var manager secretsmanager.Manager
+
+	Describe("IsConfigured()", func() {
+		JustBeforeEach(func() {
+			_, err := flags.ParseArgs(&manager, []string{})
+			Expect(err).To(BeNil())
+		})
+
+		It("fails on empty Manager", func() {
+			Expect(manager.IsConfigured()).To(BeFalse())
+		})
+
+		It("passes if AwsRegion is set", func() {
+			manager.AwsRegion = "test-region"
+			Expect(manager.IsConfigured()).To(BeTrue())
+		})
+	})
+
+	Describe("Validate()", func() {
+		JustBeforeEach(func() {
+			manager = secretsmanager.Manager{AwsRegion: "test-region"}
+			_, err := flags.ParseArgs(&manager, []string{})
+			Expect(err).To(BeNil())
+			Expect(manager.PipelineSecretTemplate).To(Equal(secretsmanager.DefaultPipelineSecretTemplate))
+			Expect(manager.TeamSecretTemplate).To(Equal(secretsmanager.DefaultTeamSecretTemplate))
+		})
+
+		It("passes on default parameters", func() {
+			Expect(manager.Validate()).To(BeNil())
+		})
+
+		DescribeTable("passes if all aws credentials are specified",
+			func(accessKey, secretKey, sessionToken string) {
+				manager.AwsAccessKeyID = accessKey
+				manager.AwsSecretAccessKey = secretKey
+				manager.AwsSessionToken = sessionToken
+				Expect(manager.Validate()).To(BeNil())
+			},
+			Entry("all values", "access", "secret", "token"),
+			Entry("access & secret", "access", "secret", ""),
+		)
+
+		DescribeTable("fails on partial AWS credentials",
+			func(accessKey, secretKey, sessionToken string) {
+				manager.AwsAccessKeyID = accessKey
+				manager.AwsSecretAccessKey = secretKey
+				manager.AwsSessionToken = sessionToken
+				Expect(manager.Validate()).ToNot(BeNil())
+			},
+			Entry("only access", "access", "", ""),
+			Entry("access & token", "access", "", "token"),
+			Entry("only secret", "", "secret", ""),
+			Entry("secret & token", "", "secret", "token"),
+			Entry("only token", "", "", "token"),
+		)
+
+		It("passes on pipe secret template containing less specialization", func() {
+			manager.PipelineSecretTemplate = "{{.Secret}}"
+			Expect(manager.Validate()).To(BeNil())
+		})
+
+		It("passes on pipe secret template containing no specialization", func() {
+			manager.PipelineSecretTemplate = "var"
+			Expect(manager.Validate()).To(BeNil())
+		})
+
+		It("fails on empty pipe secret template", func() {
+			manager.PipelineSecretTemplate = ""
+			Expect(manager.Validate()).ToNot(BeNil())
+		})
+
+		It("fails on pipe secret template containing invalid parameters", func() {
+			manager.PipelineSecretTemplate = "{{.Teams}}"
+			Expect(manager.Validate()).ToNot(BeNil())
+		})
+
+		It("passes on team secret template containing less specialization", func() {
+			manager.TeamSecretTemplate = "{{.Secret}}"
+			Expect(manager.Validate()).To(BeNil())
+		})
+
+		It("passes on team secret template containing no specialization", func() {
+			manager.TeamSecretTemplate = "var"
+			Expect(manager.Validate()).To(BeNil())
+		})
+
+		It("fails on empty team secret template", func() {
+			manager.TeamSecretTemplate = ""
+			Expect(manager.Validate()).ToNot(BeNil())
+		})
+
+		It("fails on team secret template containing invalid parameters", func() {
+			manager.TeamSecretTemplate = "{{.Teams}}"
+			Expect(manager.Validate()).ToNot(BeNil())
+		})
+	})
+})

--- a/creds/secretsmanager/secretsmanager.go
+++ b/creds/secretsmanager/secretsmanager.go
@@ -1,0 +1,114 @@
+package secretsmanager
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"text/template"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
+
+	varTemplate "github.com/cloudfoundry/bosh-cli/director/template"
+)
+
+type SecretsManager struct {
+	log             lager.Logger
+	api             secretsmanageriface.SecretsManagerAPI
+	TeamName        string
+	PipelineName    string
+	SecretTemplates []*template.Template
+}
+
+func NewSecretsManager(log lager.Logger, api secretsmanageriface.SecretsManagerAPI, teamName string, pipelineName string, secretTemplates []*template.Template) *SecretsManager {
+	return &SecretsManager{
+		log:             log,
+		api:             api,
+		TeamName:        teamName,
+		PipelineName:    pipelineName,
+		SecretTemplates: secretTemplates,
+	}
+}
+
+func (s *SecretsManager) buildSecretId(nameTemplate *template.Template, secret string) (string, error) {
+	var buf bytes.Buffer
+	err := nameTemplate.Execute(&buf, &Secret{
+		Team:     s.TeamName,
+		Pipeline: s.PipelineName,
+		Secret:   secret,
+	})
+	return buf.String(), err
+}
+
+func (s *SecretsManager) Get(varDef varTemplate.VariableDefinition) (interface{}, bool, error) {
+	for _, st := range s.SecretTemplates {
+		secretId, err := s.buildSecretId(st, varDef.Name)
+		if err != nil {
+			s.log.Error("build-secret-id", err, lager.Data{"template": st.Name(), "secret": varDef.Name})
+			return nil, false, err
+		}
+
+		if strings.Contains(secretId, "//") {
+			continue
+		}
+
+		value, found, err := s.getSecretById(secretId)
+		if err != nil {
+			s.log.Error("get-secret", err, lager.Data{
+				"template": st.Name(), "secret": varDef.Name, "secretId": secretId,
+			})
+			return nil, false, err
+		}
+		if found {
+			return value, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+/*
+	Looks up secret by name. Depending on which field is filled it will either
+	return a string value (SecretString) or a map[interface{}]interface{} (SecretBinary).
+
+	In case SecretBinary is set, it is expected to be a valid JSON object or it will error.
+*/
+func (s *SecretsManager) getSecretById(name string) (interface{}, bool, error) {
+	value, err := s.api.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: &name,
+	})
+	if err == nil {
+		switch {
+		case value.SecretString != nil:
+			return *value.SecretString, true, nil
+		case value.SecretBinary != nil:
+			values, err := decodeJsonValue(value.SecretBinary)
+			if err != nil {
+				return nil, true, err
+			}
+			return values, true, nil
+		}
+	} else if errObj, ok := err.(awserr.Error); ok && errObj.Code() == secretsmanager.ErrCodeResourceNotFoundException {
+		return nil, false, nil
+	}
+
+	return nil, false, err
+}
+
+func (s *SecretsManager) List() ([]varTemplate.VariableDefinition, error) {
+	// not implemented, see vault implementation
+	return []varTemplate.VariableDefinition{}, nil
+}
+
+func decodeJsonValue(data []byte) (map[interface{}]interface{}, error) {
+	var values map[string]interface{}
+	if err := json.Unmarshal(data, &values); err != nil {
+		return nil, err
+	}
+	evenLessTyped := map[interface{}]interface{}{}
+	for k, v := range values {
+		evenLessTyped[k] = v
+	}
+	return evenLessTyped, nil
+}

--- a/creds/secretsmanager/secretsmanager_factory.go
+++ b/creds/secretsmanager/secretsmanager_factory.go
@@ -1,0 +1,28 @@
+package secretsmanager
+
+import (
+	"text/template"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/concourse/atc/creds"
+)
+
+type secretsManagerFactory struct {
+	log             lager.Logger
+	api             *secretsmanager.SecretsManager
+	secretTemplates []*template.Template
+}
+
+func NewSecretsManagerFactory(log lager.Logger, session *session.Session, secretTemplates []*template.Template) *secretsManagerFactory {
+	return &secretsManagerFactory{
+		log:             log,
+		api:             secretsmanager.New(session),
+		secretTemplates: secretTemplates,
+	}
+}
+
+func (factory *secretsManagerFactory) NewVariables(teamName string, pipelineName string) creds.Variables {
+	return NewSecretsManager(factory.log, factory.api, teamName, pipelineName, factory.secretTemplates)
+}

--- a/creds/secretsmanager/secretsmanager_suite_test.go
+++ b/creds/secretsmanager/secretsmanager_suite_test.go
@@ -1,0 +1,13 @@
+package secretsmanager_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSsm(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SecretsManager Creds Suite")
+}

--- a/creds/secretsmanager/secretsmanager_test.go
+++ b/creds/secretsmanager/secretsmanager_test.go
@@ -1,0 +1,117 @@
+package secretsmanager_test
+
+import (
+	"errors"
+	"text/template"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
+	varTemplate "github.com/cloudfoundry/bosh-cli/director/template"
+
+	. "github.com/concourse/atc/creds/secretsmanager"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type MockSecretsManagerService struct {
+	secretsmanageriface.SecretsManagerAPI
+
+	stubGetParameter func(name string) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+func (mock *MockSecretsManagerService) GetSecretValue(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+	if mock.stubGetParameter == nil {
+		return nil, errors.New("stubGetParameter is not defined")
+	}
+	Expect(input).ToNot(BeNil())
+	Expect(input.SecretId).ToNot(BeNil())
+	value, err := mock.stubGetParameter(*input.SecretId)
+	if err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+var _ = Describe("SecretsManager", func() {
+	var secretAccess *SecretsManager
+	var varDef varTemplate.VariableDefinition
+	var mockService MockSecretsManagerService
+
+	JustBeforeEach(func() {
+		varDef = varTemplate.VariableDefinition{Name: "cheery"}
+		t1, err := template.New("test").Parse(DefaultPipelineSecretTemplate)
+		Expect(t1).NotTo(BeNil())
+		Expect(err).To(BeNil())
+		t2, err := template.New("test").Parse(DefaultTeamSecretTemplate)
+		Expect(t2).NotTo(BeNil())
+		Expect(err).To(BeNil())
+		secretAccess = NewSecretsManager(lager.NewLogger("secretsmanager_test"), &mockService, "alpha", "bogus", []*template.Template{t1, t2})
+		Expect(secretAccess).NotTo(BeNil())
+		mockService.stubGetParameter = func(input string) (*secretsmanager.GetSecretValueOutput, error) {
+			if input == "/concourse/alpha/bogus/cheery" {
+				return &secretsmanager.GetSecretValueOutput{SecretString: aws.String("secret value"), Name: &input}, nil
+			}
+			return nil, awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "", nil)
+		}
+	})
+
+	Describe("Get()", func() {
+		It("should get parameter if exists", func() {
+			value, found, err := secretAccess.Get(varDef)
+			Expect(value).To(BeEquivalentTo("secret value"))
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should get complex parameter", func() {
+			mockService.stubGetParameter = func(path string) (*secretsmanager.GetSecretValueOutput, error) {
+				return &secretsmanager.GetSecretValueOutput{
+					SecretBinary: []byte(`{"name": "yours", "pass": "truely"}`),
+				}, nil
+			}
+			value, found, err := secretAccess.Get(varTemplate.VariableDefinition{Name: "user"})
+			Expect(err).To(BeNil())
+			Expect(found).To(BeTrue())
+			Expect(value).To(BeEquivalentTo(map[interface{}]interface{}{
+				"name": "yours",
+				"pass": "truely",
+			}))
+		})
+
+		It("should get team parameter if exists", func() {
+			mockService.stubGetParameter = func(input string) (*secretsmanager.GetSecretValueOutput, error) {
+				if input != "/concourse/alpha/cheery" {
+					return nil, awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "", nil)
+				}
+				return &secretsmanager.GetSecretValueOutput{SecretString: aws.String("team decrypted value")}, nil
+			}
+			value, found, err := secretAccess.Get(varDef)
+			Expect(value).To(BeEquivalentTo("team decrypted value"))
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should return not found on error", func() {
+			mockService.stubGetParameter = nil
+			value, found, err := secretAccess.Get(varDef)
+			Expect(value).To(BeNil())
+			Expect(found).To(BeFalse())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should allow empty pipeline name", func() {
+			secretAccess.PipelineName = ""
+			mockService.stubGetParameter = func(input string) (*secretsmanager.GetSecretValueOutput, error) {
+				Expect(input).To(Equal("/concourse/alpha/cheery"))
+				return &secretsmanager.GetSecretValueOutput{SecretString: aws.String("team power")}, nil
+			}
+			value, found, err := secretAccess.Get(varDef)
+			Expect(value).To(BeEquivalentTo("team power"))
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
https://aws.amazon.com/documentation/secretsmanager/

- supports multi-value variables by storing JSON strings as SecretBinary (Example: `{"user": "user", "password": "password"}`)
- single value entries must be stored as SecretString
- retrieves secrets in the default AWSCURRENT staging label

atc must be granted the "secretsmanager:GetSecretValue" permission to be able to read secrets.

requires aws-go-sdk to be updated to at least v1.13.28 (in github.com/concourse/concourse)