### PR TITLE
If a session signing key is generated, store it in the command

### DIFF
--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -981,20 +981,16 @@ func (cmd *ATCCommand) constructWorkerPool(
 }
 
 func (cmd *ATCCommand) loadOrGenerateSigningKey() (*rsa.PrivateKey, error) {
-	var signingKey *rsa.PrivateKey
-
 	if cmd.SessionSigningKey.PrivateKey == nil {
 		generatedKey, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate session signing key: %s", err)
 		}
 
-		signingKey = generatedKey
-	} else {
-		signingKey = cmd.SessionSigningKey.PrivateKey
+		cmd.SessionSigningKey.PrivateKey = generatedKey
 	}
 
-	return signingKey, nil
+	return cmd.SessionSigningKey.PrivateKey, nil
 }
 
 func (cmd *ATCCommand) configureAuthForDefaultTeam(teamFactory db.TeamFactory) error {


### PR DESCRIPTION
In case the user doesn't provide a session signing key, we will
generate one on the fly. Instead of just returning the generated
key, we should also store it in the command, as the key in the
command is referenced in multiple other places.

Closes concourse/concourse#2152.