### PR TITLE
[WIP] Create credhub client lazily.

### DIFF
--- a/creds/credhub/credhub.go
+++ b/creds/credhub/credhub.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CredHubAtc struct {
-	CredHub *credhub.CredHub
+	CredHub lazyCredhub
 	logger  lager.Logger
 
 	PathPrefix   string
@@ -67,12 +67,17 @@ func (c CredHubAtc) findCred(path string) (credentials.Credential, bool, error) 
 	var cred credentials.Credential
 	var err error
 
-	_, err = c.CredHub.FindByPath(path)
+	ch, err := c.lazyCredhub.credhub()
 	if err != nil {
-		return cred, false, nil
+		return cred, false, err
 	}
 
-	cred, err = c.CredHub.GetLatestVersion(path)
+	_, err = ch.FindByPath(path)
+	if err != nil {
+		return cred, false, err
+	}
+
+	cred, err = ch.GetLatestVersion(path)
 	if _, ok := err.(*credhub.Error); ok {
 		return cred, false, nil
 	}

--- a/creds/credhub/credhub_factory.go
+++ b/creds/credhub/credhub_factory.go
@@ -8,19 +8,17 @@ import (
 )
 
 type credhubFactory struct {
-	credhub *credhub.CredHub
+	credhub lazyCredhub
 	logger  lager.Logger
 	prefix  string
 }
 
-func NewCredHubFactory(logger lager.Logger, credhub *credhub.CredHub, prefix string) *credhubFactory {
-	factory := &credhubFactory{
-		credhub: credhub,
+func NewCredHubFactory(logger lager.Logger, credhub lazyCredhub, prefix string) *credhubFactory {
+	return &credhubFactory{
+		credhub: lazyCredhub,
 		logger:  logger,
 		prefix:  prefix,
 	}
-
-	return factory
 }
 
 func (factory *credhubFactory) NewVariables(teamName string, pipelineName string) creds.Variables {


### PR DESCRIPTION
Creating a credhub client can fail if credhub isn't available
(specifically if we pass options that require connecting to credhub). To
allow the atc to start up when credhub is unavailable, create a lazy
credhub client that doesn't talk to credhub until the credhub provider
actually needs to look up credentials.

Not sure where to add tests--it looks like the credhub backend doesn't have any yet. WDYT @vito ?

[Resolves #2154]