### PR TITLE
Interpolate webhook_token values from cred source

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -83,7 +83,7 @@ func NewHandler(
 
 	buildServer := buildserver.NewServer(logger, externalURL, peerURL, engine, workerClient, dbTeamFactory, dbBuildFactory, eventHandlerFactory, drain)
 	jobServer := jobserver.NewServer(logger, schedulerFactory, externalURL, variablesFactory, dbJobFactory)
-	resourceServer := resourceserver.NewServer(logger, scannerFactory)
+	resourceServer := resourceserver.NewServer(logger, scannerFactory, variablesFactory)
 	versionServer := versionserver.NewServer(logger, externalURL)
 	pipelineServer := pipelineserver.NewServer(logger, dbTeamFactory, dbPipelineFactory, externalURL, engine)
 	configServer := configserver.NewServer(logger, dbTeamFactory)

--- a/api/resources_test.go
+++ b/api/resources_test.go
@@ -13,8 +13,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/cloudfoundry/bosh-cli/director/template"
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/api/accessor/accessorfakes"
+	"github.com/concourse/atc/creds"
 	"github.com/concourse/atc/db"
 	"github.com/concourse/atc/db/dbfakes"
 	"github.com/concourse/atc/radar/radarfakes"
@@ -26,6 +28,7 @@ var _ = Describe("Resources API", func() {
 		fakePipeline *dbfakes.FakePipeline
 		resource1    *dbfakes.FakeResource
 		fakeaccess   = new(accessorfakes.FakeAccess)
+		variables    creds.Variables
 	)
 
 	BeforeEach(func() {
@@ -755,7 +758,12 @@ var _ = Describe("Resources API", func() {
 
 		Context("when authorized", func() {
 			BeforeEach(func() {
-				fakeResource.WebhookTokenReturns("fake-token")
+				variables = template.StaticVariables{
+					"webhook-token": "fake-token",
+				}
+				token, err := creds.NewString(variables, "((webhook-token))").Evaluate()
+				Expect(err).NotTo(HaveOccurred())
+				fakeResource.WebhookTokenReturns(token)
 				fakePipeline.ResourceReturns(fakeResource, true, nil)
 			})
 

--- a/api/resourceserver/check_webhook.go
+++ b/api/resourceserver/check_webhook.go
@@ -6,6 +6,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/atc"
+	"github.com/concourse/atc/creds"
 	"github.com/concourse/atc/db"
 	"github.com/tedsuo/rata"
 )
@@ -37,7 +38,8 @@ func (s *Server) CheckResourceWebHook(dbPipeline db.Pipeline) http.Handler {
 			return
 		}
 
-		token := pipelineResource.WebhookToken()
+		variables := s.variablesFactory.NewVariables(dbPipeline.TeamName(), dbPipeline.Name())
+		token, err := creds.NewString(variables, pipelineResource.WebhookToken()).Evaluate()
 		if token != webhookToken {
 			logger.Info("invalid-token", lager.Data{"error": fmt.Sprintf("invalid token for webhook %s", webhookToken)})
 			w.WriteHeader(http.StatusUnauthorized)

--- a/api/resourceserver/server.go
+++ b/api/resourceserver/server.go
@@ -2,6 +2,7 @@ package resourceserver
 
 import (
 	"code.cloudfoundry.org/lager"
+	"github.com/concourse/atc/creds"
 	"github.com/concourse/atc/db"
 	"github.com/concourse/atc/radar"
 )
@@ -13,13 +14,19 @@ type ScannerFactory interface {
 }
 
 type Server struct {
-	logger         lager.Logger
-	scannerFactory ScannerFactory
+	logger           lager.Logger
+	scannerFactory   ScannerFactory
+	variablesFactory creds.VariablesFactory
 }
 
-func NewServer(logger lager.Logger, scannerFactory ScannerFactory) *Server {
+func NewServer(
+	logger lager.Logger,
+	scannerFactory ScannerFactory,
+	variablesFactory creds.VariablesFactory,
+) *Server {
 	return &Server{
-		logger:         logger,
-		scannerFactory: scannerFactory,
+		logger:           logger,
+		scannerFactory:   scannerFactory,
+		variablesFactory: variablesFactory,
 	}
 }

--- a/creds/string.go
+++ b/creds/string.go
@@ -1,0 +1,48 @@
+package creds
+
+import (
+	"github.com/concourse/atc"
+	"github.com/mitchellh/mapstructure"
+)
+
+type String struct {
+	variablesResolver Variables
+	rawCredString     string
+}
+
+func NewString(variables Variables, credString string) String {
+	return String{
+		variablesResolver: variables,
+		rawCredString:     credString,
+	}
+}
+
+func (s String) Evaluate() (string, error) {
+	var untypedInput interface{}
+
+	err := evaluate(s.variablesResolver, s.rawCredString, &untypedInput)
+	if err != nil {
+		return s.rawCredString, err
+	}
+
+	var metadata mapstructure.Metadata
+	var credString string
+
+	msConfig := &mapstructure.DecoderConfig{
+		Metadata:         &metadata,
+		Result:           &credString,
+		WeaklyTypedInput: true,
+		DecodeHook:       atc.SanitizeDecodeHook,
+	}
+
+	decoder, err := mapstructure.NewDecoder(msConfig)
+	if err != nil {
+		return s.rawCredString, err
+	}
+
+	if err := decoder.Decode(untypedInput); err != nil {
+		return s.rawCredString, err
+	}
+
+	return credString, nil
+}


### PR DESCRIPTION
A `webhook_token` should be considered a secret and have the ability to
receive its value from a cred source like Vault.