### PR TITLE
Re-enable the build reaper that was inadvertently disabled

### DIFF
--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -782,7 +782,7 @@ func (cmd *ATCCommand) Runner(positionalArguments []string) (ifrit.Runner, error
 		"pipelines",
 		"builds",
 		"collector",
-		"build-reaper",
+		"build-log-collector",
 		"static-worker",
 	},
 		32,


### PR DESCRIPTION
Appears to have been broken 2 days ago by https://github.com/concourse/atc/commit/553d292f58e6807210c52cab7a16f30d4c107254

@vito 