### PR TITLE
Add platform label to worker metrics

### DIFF
--- a/api/workerserver/heartbeat.go
+++ b/api/workerserver/heartbeat.go
@@ -44,11 +44,13 @@ func (s *Server) HeartbeatWorker(w http.ResponseWriter, r *http.Request) {
 	metric.WorkerContainers{
 		WorkerName: registration.Name,
 		Containers: registration.ActiveContainers,
+		Platform:   registration.Platform,
 	}.Emit(s.logger)
 
 	metric.WorkerVolumes{
 		WorkerName: registration.Name,
 		Volumes:    registration.ActiveVolumes,
+		Platform:   registration.Platform,
 	}.Emit(s.logger)
 
 	savedWorker, err := s.dbWorkerFactory.HeartbeatWorker(registration, ttl)

--- a/metric/emitter/prometheus.go
+++ b/metric/emitter/prometheus.go
@@ -130,7 +130,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Name:      "containers",
 			Help:      "Number of containers per worker",
 		},
-		[]string{"worker"},
+		[]string{"worker", "platform"},
 	)
 	prometheus.MustRegister(workerContainers)
 
@@ -141,7 +141,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Name:      "volumes",
 			Help:      "Number of volumes per worker",
 		},
-		[]string{"worker"},
+		[]string{"worker", "platform"},
 	)
 	prometheus.MustRegister(workerVolumes)
 
@@ -347,13 +347,17 @@ func (emitter *PrometheusEmitter) workerContainersMetric(logger lager.Logger, ev
 	if !exists {
 		logger.Error("failed-to-find-worker-in-event", fmt.Errorf("expected worker to exist in event.Attributes"))
 	}
+	platform, exists := event.Attributes["platform"]
+	if !exists {
+		logger.Error("failed-to-find-platform-in-event", fmt.Errorf("expected platform to exist in event.Attributes"))
+	}
 
 	containers, ok := event.Value.(int)
 	if !ok {
 		logger.Error("worker-volumes-event-value-type-mismatch", fmt.Errorf("expected event.Value to be an int"))
 	}
 
-	emitter.workerContainers.WithLabelValues(worker).Set(float64(containers))
+	emitter.workerContainers.WithLabelValues(worker, platform).Set(float64(containers))
 }
 
 func (emitter *PrometheusEmitter) workerVolumesMetric(logger lager.Logger, event metric.Event) {
@@ -361,13 +365,17 @@ func (emitter *PrometheusEmitter) workerVolumesMetric(logger lager.Logger, event
 	if !exists {
 		logger.Error("failed-to-find-worker-in-event", fmt.Errorf("expected worker to exist in event.Attributes"))
 	}
+	platform, exists := event.Attributes["platform"]
+	if !exists {
+		logger.Error("failed-to-find-platform-in-event", fmt.Errorf("expected platform to exist in event.Attributes"))
+	}
 
 	volumes, ok := event.Value.(int)
 	if !ok {
 		logger.Error("worker-volumes-event-value-type-mismatch", fmt.Errorf("expected event.Value to be an int"))
 	}
 
-	emitter.workerVolumes.WithLabelValues(worker).Set(float64(volumes))
+	emitter.workerVolumes.WithLabelValues(worker, platform).Set(float64(volumes))
 }
 
 func (emitter *PrometheusEmitter) httpResponseTimeMetrics(logger lager.Logger, event metric.Event) {

--- a/metric/metrics.go
+++ b/metric/metrics.go
@@ -111,6 +111,7 @@ func (event SchedulingJobDuration) Emit(logger lager.Logger) {
 
 type WorkerContainers struct {
 	WorkerName string
+	Platform   string
 	Containers int
 }
 
@@ -122,7 +123,8 @@ func (event WorkerContainers) Emit(logger lager.Logger) {
 			Value: event.Containers,
 			State: EventStateOK,
 			Attributes: map[string]string{
-				"worker": event.WorkerName,
+				"worker":   event.WorkerName,
+				"platform": event.Platform,
 			},
 		},
 	)
@@ -130,6 +132,7 @@ func (event WorkerContainers) Emit(logger lager.Logger) {
 
 type WorkerVolumes struct {
 	WorkerName string
+	Platform   string
 	Volumes    int
 }
 
@@ -141,7 +144,8 @@ func (event WorkerVolumes) Emit(logger lager.Logger) {
 			Value: event.Volumes,
 			State: EventStateOK,
 			Attributes: map[string]string{
-				"worker": event.WorkerName,
+				"worker":   event.WorkerName,
+				"platform": event.Platform,
 			},
 		},
 	)


### PR DESCRIPTION
The number of volumes/containers varies greatly per platform. In order to detect anomalies (e.g. this linux worker has to few/many volumes/containers) I think adding the platform as a label makes sense.