### PR TITLE
Add resource check metric

### DIFF
--- a/metric/metrics.go
+++ b/metric/metrics.go
@@ -388,3 +388,30 @@ func (event HTTPResponseTime) Emit(logger lager.Logger) {
 		},
 	)
 }
+
+type ResourceCheck struct {
+	PipelineName string
+	ResourceName string
+	TeamName     string
+	Success      bool
+}
+
+func (event ResourceCheck) Emit(logger lager.Logger) {
+	state := EventStateOK
+	if !event.Success {
+		state = EventStateWarning
+	}
+	emit(
+		logger.Session("resource-check"),
+		Event{
+			Name:  "resource checked",
+			Value: 1,
+			State: state,
+			Attributes: map[string]string{
+				"pipeline": event.PipelineName,
+				"resource": event.ResourceName,
+				"team":     event.TeamName,
+			},
+		},
+	)
+}

--- a/radar/resource_scanner.go
+++ b/radar/resource_scanner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/concourse/atc"
 	"github.com/concourse/atc/creds"
 	"github.com/concourse/atc/db"
+	"github.com/concourse/atc/metric"
 	"github.com/concourse/atc/resource"
 	"github.com/concourse/atc/worker"
 )
@@ -276,6 +277,12 @@ func (scanner *resourceScanner) check(
 	newVersions, err := res.Check(source, fromVersion)
 
 	scanner.setResourceCheckError(logger, savedResource, err)
+	metric.ResourceCheck{
+		PipelineName: scanner.dbPipeline.Name(),
+		ResourceName: savedResource.Name(),
+		TeamName:     scanner.dbPipeline.TeamName(),
+		Success:      err == nil,
+	}.Emit(logger)
 
 	if err != nil {
 		if rErr, ok := err.(resource.ErrResourceScriptFailed); ok {


### PR DESCRIPTION
This PR adds a metric event whenever a resource check is performed.

I think its valuable to have insights into the continuous load that is caused by the periodical resource checks that are not really reflected in the existing metrics.

For example we are seeing patterns where users create pipelines with a lot of git resources using the `path` filter for a large monorepos. This causes a lot of load on the workers (performing the checks) and also on outside resources (git repository server). Relating to https://github.com/concourse/concourse/issues/2249 I think its valuable to identify changes to pipelines (or new pipelines) that cause a spike in resource checks.

While creating this PR I wondered this rather should be be a periodically emitted counter (per pipeline) to avoid sending to much events? Assuming the resource default configuration this will emit an event about every 30 seconds for each resource. In comparison the job scheduling metrics are emitted for every active job every 10 seconds which is roughly in the same ball park.