### PR TITLE
[#35] Export Teams from Concourse Instance

### DIFF
--- a/api/present/team.go
+++ b/api/present/team.go
@@ -9,5 +9,6 @@ func Team(team db.Team) atc.Team {
 	return atc.Team{
 		ID:   team.ID(),
 		Name: team.Name(),
+		Auth: team.Auth(),
 	}
 }

--- a/api/teams_test.go
+++ b/api/teams_test.go
@@ -78,17 +78,20 @@ var _ = Describe("Teams API", func() {
 
 				fakeTeamOne.IDReturns(5)
 				fakeTeamOne.NameReturns("avengers")
+				fakeTeamOne.AuthReturns(map[string][]string{
+					"groups":[]string{}, "users":[]string{},
+				})
 
 				fakeTeamTwo.IDReturns(9)
 				fakeTeamTwo.NameReturns("aliens")
 				fakeTeamTwo.AuthReturns(map[string][]string{
-					"groups": []string{"github:org:team"},
+					"groups": []string{"github:org:team"}, "users": []string{},
 				})
 
 				fakeTeamThree.IDReturns(22)
 				fakeTeamThree.NameReturns("predators")
 				fakeTeamThree.AuthReturns(map[string][]string{
-					"users": []string{"local:username"},
+					"users": []string{"local:username"}, "groups":[]string{},
 				})
 
 				dbTeamFactory.GetTeamsReturns([]db.Team{fakeTeamOne, fakeTeamTwo, fakeTeamThree}, nil)
@@ -109,15 +112,18 @@ var _ = Describe("Teams API", func() {
 				Expect(body).To(MatchJSON(`[
  					{
  						"id": 5,
- 						"name": "avengers"
+ 						"name": "avengers",
+						"auth": {"users":[],"groups":[]}
  					},
  					{
  						"id": 9,
- 						"name": "aliens"
+ 						"name": "aliens",
+						"auth": {"groups":["github:org:team"],"users":[]}
  					},
  					{
  						"id": 22,
- 						"name": "predators"
+ 						"name": "predators",
+						"auth": {"users":["local:username"],"groups":[]}
  					}
  				]`))
 			})

--- a/api/teamserver/list.go
+++ b/api/teamserver/list.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/concourse/atc"
+	"github.com/concourse/atc/api/accessor"
 	"github.com/concourse/atc/api/present"
 )
 
@@ -18,9 +19,12 @@ func (s *Server) ListTeams(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 
-	presentedTeams := make([]atc.Team, len(teams))
-	for i, team := range teams {
-		presentedTeams[i] = present.Team(team)
+	acc := accessor.GetAccessor(r)
+	presentedTeams := make([]atc.Team, 0)
+	for _, team := range teams {
+		if  acc.IsAdmin() || acc.IsAuthorized(team.Name()) {
+			presentedTeams = append(presentedTeams, present.Team(team))
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
* Add `auth` details to `teams` api reponse

This was done to expose the authentication information set for a team, completed as part of the feature to be able to set multiple teams.

In conjunction with PR: https://github.com/concourse/fly/pull/240

Signed-off-by: Saman Alvi <salvi@pivotal.io>