### PR TITLE
Move logic to mark volumes as destroyed to gc

### DIFF
--- a/api/volumes_test.go
+++ b/api/volumes_test.go
@@ -333,13 +333,13 @@ var _ = Describe("Volumes API", func() {
 				})
 
 				It("asks the factory for the detroying volumes", func() {
-					Expect(fakeDestroyer.FindOrphanedVolumesasDestroyingCallCount()).To(Equal(1))
-					Expect(fakeDestroyer.FindOrphanedVolumesasDestroyingArgsForCall(0)).To(Equal("some-worker-name"))
+					Expect(fakeDestroyer.FindDestroyingVolumesForGcCallCount()).To(Equal(1))
+					Expect(fakeDestroyer.FindDestroyingVolumesForGcArgsForCall(0)).To(Equal("some-worker-name"))
 				})
 
 				Context("when getting all destroying volumes succeeds", func() {
 					BeforeEach(func() {
-						fakeDestroyer.FindOrphanedVolumesasDestroyingReturns([]string{
+						fakeDestroyer.FindDestroyingVolumesForGcReturns([]string{
 							"volume1",
 							"volume2",
 						}, nil)
@@ -362,7 +362,7 @@ var _ = Describe("Volumes API", func() {
 
 					Context("when getting all volumes fails", func() {
 						BeforeEach(func() {
-							fakeDestroyer.FindOrphanedVolumesasDestroyingReturns([]string{}, errors.New("oh no!"))
+							fakeDestroyer.FindDestroyingVolumesForGcReturns([]string{}, errors.New("oh no!"))
 						})
 
 						It("returns 500 Internal Server Error", func() {
@@ -372,7 +372,7 @@ var _ = Describe("Volumes API", func() {
 
 					Context("when list of volume is empty", func() {
 						BeforeEach(func() {
-							fakeDestroyer.FindOrphanedVolumesasDestroyingReturns([]string{}, nil)
+							fakeDestroyer.FindDestroyingVolumesForGcReturns([]string{}, nil)
 						})
 
 						It("returns empty list of volumes", func() {

--- a/api/volumeserver/destroying.go
+++ b/api/volumeserver/destroying.go
@@ -15,7 +15,7 @@ func (s *Server) ListDestroyingVolumes(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.Session("marked-volumes-for-worker", lager.Data{"worker_name": workerName})
 
 	if workerName != "" {
-		destroyingVolumesHandles, err := s.destroyer.FindOrphanedVolumesasDestroying(workerName)
+		destroyingVolumesHandles, err := s.destroyer.FindDestroyingVolumesForGc(workerName)
 		if err != nil {
 			logger.Error("failed-to-find-destroying-volumes", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/db/db_suite_test.go
+++ b/db/db_suite_test.go
@@ -46,6 +46,8 @@ var (
 	defaultTeam               db.Team
 	defaultWorkerPayload      atc.Worker
 	defaultWorker             db.Worker
+	otherWorker               db.Worker
+	otherWorkerPayload        atc.Worker
 	defaultResourceType       db.ResourceType
 	defaultResource           db.Resource
 	defaultPipeline           db.Pipeline
@@ -125,7 +127,16 @@ var _ = BeforeEach(func() {
 		CertsPath:       &certsPath,
 	}
 
+	otherWorkerPayload = atc.Worker{
+		ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+		Name:            "other-worker",
+		GardenAddr:      "2.3.4.5:7777",
+		BaggageclaimURL: "6.7.8.9:7878",
+		CertsPath:       &certsPath,
+	}
+
 	defaultWorker, err = workerFactory.SaveWorker(defaultWorkerPayload, 0)
+	otherWorker, err = workerFactory.SaveWorker(otherWorkerPayload, 0)
 	Expect(err).NotTo(HaveOccurred())
 
 	defaultPipeline, _, err = defaultTeam.SavePipeline("default-pipeline", atc.Config{

--- a/db/dbfakes/fake_volume_repository.go
+++ b/db/dbfakes/fake_volume_repository.go
@@ -174,20 +174,16 @@ type FakeVolumeRepository struct {
 		result1 []db.CreatedVolume
 		result2 error
 	}
-	GetOrphanedVolumesStub        func(workerName string) ([]db.CreatedVolume, []string, error)
+	GetOrphanedVolumesStub        func() ([]db.CreatedVolume, error)
 	getOrphanedVolumesMutex       sync.RWMutex
-	getOrphanedVolumesArgsForCall []struct {
-		workerName string
-	}
-	getOrphanedVolumesReturns struct {
+	getOrphanedVolumesArgsForCall []struct{}
+	getOrphanedVolumesReturns     struct {
 		result1 []db.CreatedVolume
-		result2 []string
-		result3 error
+		result2 error
 	}
 	getOrphanedVolumesReturnsOnCall map[int]struct {
 		result1 []db.CreatedVolume
-		result2 []string
-		result3 error
+		result2 error
 	}
 	DestroyFailedVolumesStub        func() (int, error)
 	destroyFailedVolumesMutex       sync.RWMutex
@@ -835,21 +831,19 @@ func (fake *FakeVolumeRepository) FindVolumesForContainerReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
-func (fake *FakeVolumeRepository) GetOrphanedVolumes(workerName string) ([]db.CreatedVolume, []string, error) {
+func (fake *FakeVolumeRepository) GetOrphanedVolumes() ([]db.CreatedVolume, error) {
 	fake.getOrphanedVolumesMutex.Lock()
 	ret, specificReturn := fake.getOrphanedVolumesReturnsOnCall[len(fake.getOrphanedVolumesArgsForCall)]
-	fake.getOrphanedVolumesArgsForCall = append(fake.getOrphanedVolumesArgsForCall, struct {
-		workerName string
-	}{workerName})
-	fake.recordInvocation("GetOrphanedVolumes", []interface{}{workerName})
+	fake.getOrphanedVolumesArgsForCall = append(fake.getOrphanedVolumesArgsForCall, struct{}{})
+	fake.recordInvocation("GetOrphanedVolumes", []interface{}{})
 	fake.getOrphanedVolumesMutex.Unlock()
 	if fake.GetOrphanedVolumesStub != nil {
-		return fake.GetOrphanedVolumesStub(workerName)
+		return fake.GetOrphanedVolumesStub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fake.getOrphanedVolumesReturns.result1, fake.getOrphanedVolumesReturns.result2, fake.getOrphanedVolumesReturns.result3
+	return fake.getOrphanedVolumesReturns.result1, fake.getOrphanedVolumesReturns.result2
 }
 
 func (fake *FakeVolumeRepository) GetOrphanedVolumesCallCount() int {
@@ -858,35 +852,26 @@ func (fake *FakeVolumeRepository) GetOrphanedVolumesCallCount() int {
 	return len(fake.getOrphanedVolumesArgsForCall)
 }
 
-func (fake *FakeVolumeRepository) GetOrphanedVolumesArgsForCall(i int) string {
-	fake.getOrphanedVolumesMutex.RLock()
-	defer fake.getOrphanedVolumesMutex.RUnlock()
-	return fake.getOrphanedVolumesArgsForCall[i].workerName
-}
-
-func (fake *FakeVolumeRepository) GetOrphanedVolumesReturns(result1 []db.CreatedVolume, result2 []string, result3 error) {
+func (fake *FakeVolumeRepository) GetOrphanedVolumesReturns(result1 []db.CreatedVolume, result2 error) {
 	fake.GetOrphanedVolumesStub = nil
 	fake.getOrphanedVolumesReturns = struct {
 		result1 []db.CreatedVolume
-		result2 []string
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeVolumeRepository) GetOrphanedVolumesReturnsOnCall(i int, result1 []db.CreatedVolume, result2 []string, result3 error) {
+func (fake *FakeVolumeRepository) GetOrphanedVolumesReturnsOnCall(i int, result1 []db.CreatedVolume, result2 error) {
 	fake.GetOrphanedVolumesStub = nil
 	if fake.getOrphanedVolumesReturnsOnCall == nil {
 		fake.getOrphanedVolumesReturnsOnCall = make(map[int]struct {
 			result1 []db.CreatedVolume
-			result2 []string
-			result3 error
+			result2 error
 		})
 	}
 	fake.getOrphanedVolumesReturnsOnCall[i] = struct {
 		result1 []db.CreatedVolume
-		result2 []string
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeVolumeRepository) DestroyFailedVolumes() (int, error) {

--- a/db/volume_repository_test.go
+++ b/db/volume_repository_test.go
@@ -171,7 +171,6 @@ var _ = Describe("VolumeFactory", func() {
 				StepName: "some-task",
 			})
 			Expect(err).ToNot(HaveOccurred())
-
 			expectedCreatedHandles = []string{}
 			expectedDestroyingHandles = []string{}
 
@@ -194,6 +193,12 @@ var _ = Describe("VolumeFactory", func() {
 			destroyingVolume3, err := createdVolume3.Destroying()
 			Expect(err).NotTo(HaveOccurred())
 			expectedDestroyingHandles = append(expectedDestroyingHandles, destroyingVolume3.Handle())
+
+			creatingVolumeOtherWorker, err := volumeRepository.CreateContainerVolume(defaultTeam.ID(), otherWorker.Name(), creatingContainer, "some-path-other-1")
+			Expect(err).NotTo(HaveOccurred())
+			createdVolumeOtherWorker, err := creatingVolumeOtherWorker.Created()
+			Expect(err).NotTo(HaveOccurred())
+			expectedCreatedHandles = append(expectedCreatedHandles, createdVolumeOtherWorker.Handle())
 
 			resourceCacheVolume, err := volumeRepository.CreateContainerVolume(defaultTeam.ID(), defaultWorker.Name(), creatingContainer, "some-path-4")
 			Expect(err).NotTo(HaveOccurred())
@@ -264,19 +269,15 @@ var _ = Describe("VolumeFactory", func() {
 		})
 
 		It("returns orphaned volumes", func() {
-			createdVolumes, destoryingVolumesHandles, err := volumeRepository.GetOrphanedVolumes(defaultWorker.Name())
+			createdVolumes, err := volumeRepository.GetOrphanedVolumes()
 			Expect(err).NotTo(HaveOccurred())
 			createdHandles := []string{}
 
 			for _, vol := range createdVolumes {
 				createdHandles = append(createdHandles, vol.Handle())
-				Expect(vol.WorkerName()).To(Equal("default-worker"))
 			}
 			Expect(createdHandles).To(Equal(expectedCreatedHandles))
 			Expect(createdHandles).ToNot(ContainElement(certsVolumeHandle))
-
-			Expect(destoryingVolumesHandles).To(Equal(expectedDestroyingHandles))
-			Expect(destoryingVolumesHandles).ToNot(ContainElement(certsVolumeHandle))
 		})
 
 		Context("when worker is stalled", func() {
@@ -289,11 +290,16 @@ var _ = Describe("VolumeFactory", func() {
 				Expect(stalledWorkers).To(ContainElement(defaultWorker.Name()))
 			})
 
-			It("does not return volumes", func() {
-				createdVolumes, destoryingVolumes, err := volumeRepository.GetOrphanedVolumes(defaultWorker.Name())
+			It("does not return volumes from stalled worker", func() {
+				createdVolumes, err := volumeRepository.GetOrphanedVolumes()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(createdVolumes).To(HaveLen(0))
-				Expect(destoryingVolumes).To(HaveLen(0))
+				createdHandles := []string{}
+
+				for _, vol := range createdVolumes {
+					createdHandles = append(createdHandles, vol.Handle())
+					Expect(vol.WorkerName()).To(Equal("other-worker"))
+				}
+				Expect(createdHandles).To(HaveLen(1))
 			})
 		})
 
@@ -307,10 +313,15 @@ var _ = Describe("VolumeFactory", func() {
 			})
 
 			It("does not return volumes", func() {
-				createdVolumes, destoryingVolumes, err := volumeRepository.GetOrphanedVolumes(defaultWorker.Name())
+				createdVolumes, err := volumeRepository.GetOrphanedVolumes()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(createdVolumes).To(HaveLen(0))
-				Expect(destoryingVolumes).To(HaveLen(0))
+				createdHandles := []string{}
+
+				for _, vol := range createdVolumes {
+					createdHandles = append(createdHandles, vol.Handle())
+					Expect(vol.WorkerName()).To(Equal("other-worker"))
+				}
+				Expect(createdVolumes).To(HaveLen(1))
 			})
 		})
 	})

--- a/gc/gcfakes/fake_destroyer.go
+++ b/gc/gcfakes/fake_destroyer.go
@@ -8,16 +8,16 @@ import (
 )
 
 type FakeDestroyer struct {
-	FindOrphanedVolumesasDestroyingStub        func(workerName string) ([]string, error)
-	findOrphanedVolumesasDestroyingMutex       sync.RWMutex
-	findOrphanedVolumesasDestroyingArgsForCall []struct {
+	FindDestroyingVolumesForGcStub        func(workerName string) ([]string, error)
+	findDestroyingVolumesForGcMutex       sync.RWMutex
+	findDestroyingVolumesForGcArgsForCall []struct {
 		workerName string
 	}
-	findOrphanedVolumesasDestroyingReturns struct {
+	findDestroyingVolumesForGcReturns struct {
 		result1 []string
 		result2 error
 	}
-	findOrphanedVolumesasDestroyingReturnsOnCall map[int]struct {
+	findDestroyingVolumesForGcReturnsOnCall map[int]struct {
 		result1 []string
 		result2 error
 	}
@@ -49,52 +49,52 @@ type FakeDestroyer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeDestroyer) FindOrphanedVolumesasDestroying(workerName string) ([]string, error) {
-	fake.findOrphanedVolumesasDestroyingMutex.Lock()
-	ret, specificReturn := fake.findOrphanedVolumesasDestroyingReturnsOnCall[len(fake.findOrphanedVolumesasDestroyingArgsForCall)]
-	fake.findOrphanedVolumesasDestroyingArgsForCall = append(fake.findOrphanedVolumesasDestroyingArgsForCall, struct {
+func (fake *FakeDestroyer) FindDestroyingVolumesForGc(workerName string) ([]string, error) {
+	fake.findDestroyingVolumesForGcMutex.Lock()
+	ret, specificReturn := fake.findDestroyingVolumesForGcReturnsOnCall[len(fake.findDestroyingVolumesForGcArgsForCall)]
+	fake.findDestroyingVolumesForGcArgsForCall = append(fake.findDestroyingVolumesForGcArgsForCall, struct {
 		workerName string
 	}{workerName})
-	fake.recordInvocation("FindOrphanedVolumesasDestroying", []interface{}{workerName})
-	fake.findOrphanedVolumesasDestroyingMutex.Unlock()
-	if fake.FindOrphanedVolumesasDestroyingStub != nil {
-		return fake.FindOrphanedVolumesasDestroyingStub(workerName)
+	fake.recordInvocation("FindDestroyingVolumesForGc", []interface{}{workerName})
+	fake.findDestroyingVolumesForGcMutex.Unlock()
+	if fake.FindDestroyingVolumesForGcStub != nil {
+		return fake.FindDestroyingVolumesForGcStub(workerName)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.findOrphanedVolumesasDestroyingReturns.result1, fake.findOrphanedVolumesasDestroyingReturns.result2
+	return fake.findDestroyingVolumesForGcReturns.result1, fake.findDestroyingVolumesForGcReturns.result2
 }
 
-func (fake *FakeDestroyer) FindOrphanedVolumesasDestroyingCallCount() int {
-	fake.findOrphanedVolumesasDestroyingMutex.RLock()
-	defer fake.findOrphanedVolumesasDestroyingMutex.RUnlock()
-	return len(fake.findOrphanedVolumesasDestroyingArgsForCall)
+func (fake *FakeDestroyer) FindDestroyingVolumesForGcCallCount() int {
+	fake.findDestroyingVolumesForGcMutex.RLock()
+	defer fake.findDestroyingVolumesForGcMutex.RUnlock()
+	return len(fake.findDestroyingVolumesForGcArgsForCall)
 }
 
-func (fake *FakeDestroyer) FindOrphanedVolumesasDestroyingArgsForCall(i int) string {
-	fake.findOrphanedVolumesasDestroyingMutex.RLock()
-	defer fake.findOrphanedVolumesasDestroyingMutex.RUnlock()
-	return fake.findOrphanedVolumesasDestroyingArgsForCall[i].workerName
+func (fake *FakeDestroyer) FindDestroyingVolumesForGcArgsForCall(i int) string {
+	fake.findDestroyingVolumesForGcMutex.RLock()
+	defer fake.findDestroyingVolumesForGcMutex.RUnlock()
+	return fake.findDestroyingVolumesForGcArgsForCall[i].workerName
 }
 
-func (fake *FakeDestroyer) FindOrphanedVolumesasDestroyingReturns(result1 []string, result2 error) {
-	fake.FindOrphanedVolumesasDestroyingStub = nil
-	fake.findOrphanedVolumesasDestroyingReturns = struct {
+func (fake *FakeDestroyer) FindDestroyingVolumesForGcReturns(result1 []string, result2 error) {
+	fake.FindDestroyingVolumesForGcStub = nil
+	fake.findDestroyingVolumesForGcReturns = struct {
 		result1 []string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeDestroyer) FindOrphanedVolumesasDestroyingReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.FindOrphanedVolumesasDestroyingStub = nil
-	if fake.findOrphanedVolumesasDestroyingReturnsOnCall == nil {
-		fake.findOrphanedVolumesasDestroyingReturnsOnCall = make(map[int]struct {
+func (fake *FakeDestroyer) FindDestroyingVolumesForGcReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.FindDestroyingVolumesForGcStub = nil
+	if fake.findDestroyingVolumesForGcReturnsOnCall == nil {
+		fake.findDestroyingVolumesForGcReturnsOnCall = make(map[int]struct {
 			result1 []string
 			result2 error
 		})
 	}
-	fake.findOrphanedVolumesasDestroyingReturnsOnCall[i] = struct {
+	fake.findDestroyingVolumesForGcReturnsOnCall[i] = struct {
 		result1 []string
 		result2 error
 	}{result1, result2}
@@ -211,8 +211,8 @@ func (fake *FakeDestroyer) DestroyVolumesReturnsOnCall(i int, result1 error) {
 func (fake *FakeDestroyer) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.findOrphanedVolumesasDestroyingMutex.RLock()
-	defer fake.findOrphanedVolumesasDestroyingMutex.RUnlock()
+	fake.findDestroyingVolumesForGcMutex.RLock()
+	defer fake.findDestroyingVolumesForGcMutex.RUnlock()
 	fake.destroyContainersMutex.RLock()
 	defer fake.destroyContainersMutex.RUnlock()
 	fake.destroyVolumesMutex.RLock()

--- a/gc/volume_collector_test.go
+++ b/gc/volume_collector_test.go
@@ -22,8 +22,10 @@ var _ = Describe("VolumeCollector", func() {
 		workerFactory      db.WorkerFactory
 		fakeBCVolume       *baggageclaimfakes.FakeVolume
 		creatingContainer1 db.CreatingContainer
+		creatingContainer2 db.CreatingContainer
 		team               db.Team
 		worker             db.Worker
+		build              db.Build
 
 		fakeWorker *workerfakes.FakeWorker
 	)
@@ -45,30 +47,31 @@ var _ = Describe("VolumeCollector", func() {
 
 	Describe("Run", func() {
 
+		BeforeEach(func() {
+			var err error
+			team, err = teamFactory.CreateTeam(atc.Team{Name: "some-team"})
+			Expect(err).ToNot(HaveOccurred())
+
+			build, err = team.CreateOneOffBuild()
+			Expect(err).ToNot(HaveOccurred())
+
+			worker, err = workerFactory.SaveWorker(atc.Worker{
+				Name:            "some-worker",
+				GardenAddr:      "1.2.3.4:7777",
+				BaggageclaimURL: "1.2.3.4:7788",
+			}, 5*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			creatingContainer1, err = team.CreateContainer(worker.Name(), db.NewBuildStepContainerOwner(build.ID(), "some-plan"), db.ContainerMetadata{
+				Type:     "task",
+				StepName: "some-task",
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
 		Context("when there are failed volumes", func() {
 			var failedVolume1 db.FailedVolume
 
-			BeforeEach(func() {
-				var err error
-				team, err = teamFactory.CreateTeam(atc.Team{Name: "some-team"})
-				Expect(err).ToNot(HaveOccurred())
-
-				build, err := team.CreateOneOffBuild()
-				Expect(err).ToNot(HaveOccurred())
-
-				worker, err = workerFactory.SaveWorker(atc.Worker{
-					Name:            "some-worker",
-					GardenAddr:      "1.2.3.4:7777",
-					BaggageclaimURL: "1.2.3.4:7788",
-				}, 5*time.Minute)
-				Expect(err).ToNot(HaveOccurred())
-
-				creatingContainer1, err = team.CreateContainer(worker.Name(), db.NewBuildStepContainerOwner(build.ID(), "some-plan"), db.ContainerMetadata{
-					Type:     "task",
-					StepName: "some-task",
-				})
-				Expect(err).ToNot(HaveOccurred())
-
+			JustBeforeEach(func() {
 				creatingVolume1, err := volumeRepository.CreateContainerVolume(team.ID(), worker.Name(), creatingContainer1, "some-path-1")
 				Expect(err).NotTo(HaveOccurred())
 
@@ -88,6 +91,57 @@ var _ = Describe("VolumeCollector", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(failedVolumesLen).To(Equal(0))
 			})
+		})
+
+		Context("when there are orphaned volumes", func() {
+			var createdVolume1 db.CreatedVolume
+			var expectedOrphanedVolumeHandles []string
+
+			JustBeforeEach(func() {
+
+				creatingContainer2, err = team.CreateContainer(worker.Name(), db.NewBuildStepContainerOwner(build.ID(), "some-plan"), db.ContainerMetadata{
+					Type:     "task",
+					StepName: "some-task",
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				creatingVolume1, err := volumeRepository.CreateContainerVolume(team.ID(), worker.Name(), creatingContainer1, "some-path-1")
+				Expect(err).NotTo(HaveOccurred())
+				expectedOrphanedVolumeHandles = append(expectedOrphanedVolumeHandles, creatingVolume1.Handle())
+
+				createdVolume1, err = creatingVolume1.Created()
+
+				creatingVolume2, err := volumeRepository.CreateContainerVolume(team.ID(), worker.Name(), creatingContainer2, "some-path-1")
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = creatingVolume2.Created()
+				Expect(err).NotTo(HaveOccurred())
+
+				createdContainer1, err := creatingContainer1.Created()
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = creatingContainer2.Created()
+				Expect(err).NotTo(HaveOccurred())
+
+				destroyingContainer, err := createdContainer1.Destroying()
+				Expect(err).NotTo(HaveOccurred())
+
+				destroyed, err := destroyingContainer.Destroy()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(destroyed).To(BeTrue())
+
+			})
+			It("marks orphaned volumes as 'destroying'", func() {
+				err = volumeCollector.Run(context.TODO())
+				Expect(err).NotTo(HaveOccurred())
+
+				destroyingVolumes, err := volumeRepository.GetDestroyingVolumes(worker.Name())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(destroyingVolumes).To(HaveLen(1))
+
+				Expect(destroyingVolumes).To(Equal(expectedOrphanedVolumeHandles))
+			})
+
 		})
 	})
 })


### PR DESCRIPTION
This is a fix for [#2375](https://github.com/concourse/concourse/issues/2375). It moves the responsibility of marking orphaned volumes as `destroying` to `gc`, instead of in the `api/ListDestroyingVolumes` endpoint.