### PR TITLE
Validate that params are declared in task file before merging

### DIFF
--- a/exec/task_config_source.go
+++ b/exec/task_config_source.go
@@ -177,7 +177,7 @@ func (configSource MergedConfigSource) FetchConfig(source *worker.ArtifactReposi
 		return atc.TaskConfig{}, err
 	}
 
-	return aConfig.Merge(bConfig), nil
+	return aConfig.Merge(bConfig)
 }
 
 func (configSource MergedConfigSource) Warnings() []string {

--- a/exec/task_config_source_test.go
+++ b/exec/task_config_source_test.go
@@ -438,6 +438,16 @@ run: {path: a/file}
 					}))
 				})
 
+				Context("but B defines a param not in A", func() {
+					BeforeEach(func() {
+						configB.Params["EXTRA_PARAM"] = "EXTRA_PARAM isn't defined in task file"
+					})
+
+					It("should fail", func() {
+						Expect(fetchErr).To(HaveOccurred())
+					})
+				})
+
 			})
 
 			Context("and fetching via B fails", func() {

--- a/task_test.go
+++ b/task_test.go
@@ -715,7 +715,6 @@ run: {path: a/file}
 			}.Merge(TaskConfig{
 				Params: map[string]string{
 					"FOO": "3",
-					"BAZ": "4",
 				},
 			})).To(
 
@@ -724,10 +723,25 @@ run: {path: a/file}
 					Params: map[string]string{
 						"FOO": "3",
 						"BAR": "2",
-						"BAZ": "4",
 					},
 				}))
 
+		})
+
+		It("errors if params key in pipeline.yml is not defined in task.yml", func() {
+			_, err := TaskConfig{
+				RootfsURI: "some-image",
+				Params: map[string]string{
+					"FOO": "1",
+					"BAR": "2",
+				},
+			}.Merge(TaskConfig{
+				Params: map[string]string{
+					"FOO": "3",
+					"BAZ": "4",
+				},
+			})
+			Expect(err.Error()).To(ContainSubstring("BAZ was defined in pipeline but missing from task file"))
 		})
 
 		It("overrides the platform", func() {


### PR DESCRIPTION
For tasks defined by `file: task.yml`, if params are defined in the outer task step, but not declared within the task.yml file, return an error.  This addresses concourse/concourse#555.

It would also be nice to update `fly set-pipeline` with the same type of validation for faster feedback, but I don't know how to implement that.