### PR TITLE
Create migration CLI to generate migrations

### DIFF
--- a/db/migration/cli/command/command.go
+++ b/db/migration/cli/command/command.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"text/template"
+	"time"
+)
+
+var defaultMigrationDir = "migrations/"
+
+type MigrationType string
+
+const (
+	SQL MigrationType = "sql"
+	Go  MigrationType = "go"
+)
+
+type MigrationCommand struct {
+	GenerateCommand GenerateCommand `command:"generate"`
+}
+
+type GenerateCommand struct {
+	MigrationDirectory string        `short:"d" long:"directory" default:"migrations" description:"The directory to which the migration files should be written"`
+	MigrationName      string        `short:"n" long:"name" description:"The name of the migration"`
+	Type               MigrationType `short:"t" long:"type" description:"The file type of the migration"`
+}
+
+func NewGenerateCommand(migrationDir string, migrationName string, migrationType MigrationType) *GenerateCommand {
+	if migrationDir == "" {
+		migrationDir = defaultMigrationDir
+	}
+
+	return &GenerateCommand{
+		migrationDir,
+		migrationName,
+		migrationType,
+	}
+}
+
+func (c *GenerateCommand) Execute(args []string) error {
+	if c.Type == SQL {
+		return c.GenerateSQLMigration()
+	} else if c.Type == Go {
+		return c.GenerateGoMigration()
+	}
+	return fmt.Errorf("unsupported migration type %s. Supported types include %s and %s", c.Type, SQL, Go)
+}
+
+func (c *GenerateCommand) GenerateSQLMigration() error {
+	currentTime := time.Now().Unix()
+	fileNameFormat := "%d_%s.%s.sql"
+
+	upMigrationFileName := fmt.Sprintf(fileNameFormat, currentTime, c.MigrationName, "up")
+	downMigrationFileName := fmt.Sprintf(fileNameFormat, currentTime, c.MigrationName, "down")
+
+	contents := ""
+
+	err := ioutil.WriteFile(path.Join(c.MigrationDirectory, upMigrationFileName), []byte(contents), os.ModePerm)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(path.Join(c.MigrationDirectory, downMigrationFileName), []byte(contents), os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type migrationInfo struct {
+	MigrationId int64
+	Direction   string
+}
+
+const goMigrationTemplate = `package migrations
+
+// implement the migration in this function
+func {{ .Direction }}_{{ .MigrationId }}() error {
+	return nil
+}`
+
+func renderGoMigrationToFile(filePath string, state migrationInfo) error {
+	migrationFile, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer migrationFile.Close()
+
+	tmpl, err := template.New("go-migration-template").Parse(goMigrationTemplate)
+	if err != nil {
+		return err
+	}
+
+	err = tmpl.Execute(migrationFile, state)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *GenerateCommand) GenerateGoMigration() error {
+	currentTime := time.Now().Unix()
+	fileNameFormat := "%d_%s.%s.go"
+
+	upMigrationFileName := fmt.Sprintf(fileNameFormat, currentTime, c.MigrationName, "up")
+	downMigrationFileName := fmt.Sprintf(fileNameFormat, currentTime, c.MigrationName, "down")
+
+	err := renderGoMigrationToFile(path.Join(c.MigrationDirectory, upMigrationFileName), migrationInfo{
+		MigrationId: currentTime,
+		Direction:   "Up",
+	})
+	if err != nil {
+		return err
+	}
+
+	err = renderGoMigrationToFile(path.Join(c.MigrationDirectory, downMigrationFileName), migrationInfo{
+		MigrationId: currentTime,
+		Direction:   "Down",
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/db/migration/cli/command/command_suite_test.go
+++ b/db/migration/cli/command/command_suite_test.go
@@ -1,0 +1,13 @@
+package cli_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Command Suite")
+}

--- a/db/migration/cli/command/command_test.go
+++ b/db/migration/cli/command/command_test.go
@@ -1,0 +1,100 @@
+package cli_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	cmd "github.com/concourse/atc/db/migration/cli/command"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Migration CLI", func() {
+
+	Context("generate migration files", func() {
+		var (
+			migrationDir  string
+			command       *cmd.GenerateCommand
+			migrationName = "create_new_table"
+			err           error
+		)
+
+		BeforeEach(func() {
+			migrationDir, err = ioutil.TempDir("", "")
+			Expect(err).ToNot(HaveOccurred())
+
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(migrationDir)
+		})
+
+		Context("sql migrations", func() {
+
+			It("generates up and down migration files", func() {
+				command = cmd.NewGenerateCommand(migrationDir, migrationName, "sql")
+				sqlMigrationPattern := "^(\\d+)_(.*).(down|up).sql$"
+
+				err := command.GenerateSQLMigration()
+				Expect(err).ToNot(HaveOccurred())
+
+				ExpectGeneratedFilesToMatchSpecification(migrationDir, sqlMigrationPattern,
+					migrationName, func(migrationID string, actualFileContents string) {
+						Expect(actualFileContents).To(BeEmpty())
+					})
+			})
+		})
+
+		Context("go migration", func() {
+			It("generates up and down migration files", func() {
+				command = cmd.NewGenerateCommand(migrationDir, migrationName, "go")
+				goMigrationPattern := "^(\\d+)_(.*).(down|up).go$"
+
+				err := command.GenerateGoMigration()
+				Expect(err).ToNot(HaveOccurred())
+
+				ExpectGeneratedFilesToMatchSpecification(migrationDir, goMigrationPattern,
+					migrationName, func(migrationID string, actualFileContents string) {
+						lines := strings.Split(actualFileContents, "\n")
+						Expect(lines).To(HaveLen(6))
+
+						Expect(lines[0]).To(Equal("package migrations"))
+						Expect(lines[1]).To(Equal(""))
+						Expect(lines[2]).To(HavePrefix("//"))
+						Expect(lines[3]).To(MatchRegexp("^func (Up|Down)_%s\\(\\) error {", migrationID))
+						Expect(lines[4]).To(ContainSubstring("return nil"))
+						Expect(lines[5]).To(Equal("}"))
+					})
+			})
+
+		})
+	})
+})
+
+func ExpectGeneratedFilesToMatchSpecification(migrationDir, fileNamePattern, migrationName string,
+	checkContents func(migrationID string, actualFileContents string)) {
+
+	files, err := ioutil.ReadDir(migrationDir)
+	Expect(err).ToNot(HaveOccurred())
+	var migrationFilesCount = 0
+	regex := regexp.MustCompile(fileNamePattern)
+	for _, migrationFile := range files {
+		var matches []string
+		migrationFileName := migrationFile.Name()
+		if regex.MatchString(migrationFileName) {
+			matches = regex.FindStringSubmatch(migrationFileName)
+
+			Expect(matches).To(HaveLen(4))
+			Expect(matches[2]).To(Equal(migrationName))
+
+			fileContents, err := ioutil.ReadFile(path.Join(migrationDir, migrationFileName))
+			Expect(err).ToNot(HaveOccurred())
+			checkContents(matches[1], string(fileContents))
+			migrationFilesCount++
+		}
+	}
+	Expect(migrationFilesCount).To(Equal(2))
+}

--- a/db/migration/cli/main.go
+++ b/db/migration/cli/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+
+	command "github.com/concourse/atc/db/migration/cli/command"
+	flags "github.com/jessevdk/go-flags"
+)
+
+func main() {
+	cmd := &command.MigrationCommand{}
+
+	parser := flags.NewParser(cmd, flags.Default)
+	parser.Command.Find("generate")
+	_, err := parser.Parse()
+	if err != nil {
+		os.Stderr.WriteString(err.Error())
+		os.Exit(1)
+	}
+}

--- a/scripts/create-migration
+++ b/scripts/create-migration
@@ -2,6 +2,6 @@
 
 set -e -u
 
-go build -tags 'postgres' -o $GOPATH/bin/migrate github.com/mattes/migrate/cli
+go build -tags 'postgres' -o $GOPATH/bin/migrate github.com/concourse/atc/db/migration/cli
 
-migrate create -ext sql -dir db/migration/migrations/ "$@"
+migrate generate -d db/migration/migrations/ -n"$1" -t ${2-"sql"}


### PR DESCRIPTION
The old `mattes/migrate` library had a CLI that we used to generate migrations. This PR creates our own version using `jessevdk/go-flags` and our migration library. It also updates `scripts/create-migration` to use the new CLI.

The new CLI supports generation of both Go and SQL migrations.