### PR TITLE
Change error to warning for task params defined in pipeline but not task.yml

### DIFF
--- a/exec/garden_factory.go
+++ b/exec/garden_factory.go
@@ -125,7 +125,7 @@ func (factory *gardenFactory) Task(
 
 	var taskConfigSource TaskConfigSource
 	if plan.Task.ConfigPath != "" && (plan.Task.Config != nil || plan.Task.Params != nil) {
-		taskConfigSource = MergedConfigSource{
+		taskConfigSource = &MergedConfigSource{
 			A: FileConfigSource{plan.Task.ConfigPath},
 			B: StaticConfigSource{Plan: *plan.Task},
 		}

--- a/exec/garden_factory.go
+++ b/exec/garden_factory.go
@@ -137,11 +137,6 @@ func (factory *gardenFactory) Task(
 
 	taskConfigSource = ValidatingConfigSource{ConfigSource: taskConfigSource}
 
-	taskConfigSource = DeprecationConfigSource{
-		Delegate: taskConfigSource,
-		Stderr:   delegate.Stderr(),
-	}
-
 	variables := factory.variablesFactory.NewVariables(build.TeamName(), build.PipelineName())
 
 	taskStep := NewTaskStep(

--- a/exec/task_config_source.go
+++ b/exec/task_config_source.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"math"
 	"strconv"
@@ -69,26 +68,6 @@ func (configSource StaticConfigSource) FetchConfig(*worker.ArtifactRepository) (
 
 func (configSource StaticConfigSource) Warnings() []string {
 	return []string{}
-}
-
-// DeprecationConfigSource returns the Delegate TaskConfig and prints warnings to Stderr.
-type DeprecationConfigSource struct {
-	Delegate TaskConfigSource
-	Stderr   io.Writer
-}
-
-// FetchConfig calls the Delegate's FetchConfig and prints warnings to Stderr
-func (configSource DeprecationConfigSource) FetchConfig(repo *worker.ArtifactRepository) (atc.TaskConfig, error) {
-	taskConfig, err := configSource.Delegate.FetchConfig(repo)
-	if err != nil {
-		return atc.TaskConfig{}, err
-	}
-
-	return taskConfig, nil
-}
-
-func (configSource DeprecationConfigSource) Warnings() []string {
-	return configSource.Delegate.Warnings()
 }
 
 // FileConfigSource represents a dynamically configured TaskConfig, which will

--- a/exec/task_config_source_test.go
+++ b/exec/task_config_source_test.go
@@ -384,7 +384,7 @@ run: {path: a/file}
 			fakeConfigSourceA = new(execfakes.FakeTaskConfigSource)
 			fakeConfigSourceB = new(execfakes.FakeTaskConfigSource)
 
-			configSource = MergedConfigSource{
+			configSource = &MergedConfigSource{
 				A: fakeConfigSourceA,
 				B: fakeConfigSourceB,
 			}
@@ -443,8 +443,13 @@ run: {path: a/file}
 						configB.Params["EXTRA_PARAM"] = "EXTRA_PARAM isn't defined in task file"
 					})
 
-					It("should fail", func() {
-						Expect(fetchErr).To(HaveOccurred())
+					It("should have a warning", func() {
+						Expect(configSource.Warnings()).To(HaveLen(1))
+						Expect(configSource.Warnings()[0]).To(ContainSubstring("EXTRA_PARAM was defined in pipeline but missing from task file"))
+					})
+
+					It("should not fail", func() {
+						Expect(fetchErr).ToNot(HaveOccurred())
 					})
 				})
 

--- a/exec/task_config_source_test.go
+++ b/exec/task_config_source_test.go
@@ -58,64 +58,6 @@ var _ = Describe("TaskConfigSource", func() {
 		}
 	})
 
-	Describe("DeprecationConfigSource", func() {
-		var (
-			configSource TaskConfigSource
-			stderrBuf    *gbytes.Buffer
-		)
-
-		JustBeforeEach(func() {
-			delegate := StaticConfigSource{Plan: taskPlan}
-			stderrBuf = gbytes.NewBuffer()
-			configSource = DeprecationConfigSource{
-				Delegate: &delegate,
-				Stderr:   stderrBuf,
-			}
-		})
-
-		It("merges task params prefering params in task plan", func() {
-			fetchedConfig, err := configSource.FetchConfig(repo)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fetchedConfig.Params).To(Equal(map[string]string{
-				"task-plan-param-key":   "task-plan-param-val-1",
-				"task-config-param-key": "task-config-param-val-1",
-				"common-key":            "task-plan-param-val-2",
-			}))
-		})
-
-		Context("when task config params are not set", func() {
-			BeforeEach(func() {
-				taskConfig = atc.TaskConfig{}
-			})
-
-			It("uses params from task plan", func() {
-				fetchedConfig, err := configSource.FetchConfig(repo)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(fetchedConfig.Params).To(Equal(map[string]string{
-					"task-plan-param-key": "task-plan-param-val-1",
-					"common-key":          "task-plan-param-val-2",
-				}))
-			})
-		})
-
-		Context("when task plan params are not set", func() {
-			BeforeEach(func() {
-				taskPlan = atc.TaskPlan{
-					Config: &taskConfig,
-				}
-			})
-
-			It("uses params from task config", func() {
-				fetchedConfig, err := configSource.FetchConfig(repo)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(fetchedConfig.Params).To(Equal(map[string]string{
-					"task-config-param-key": "task-config-param-val-1",
-					"common-key":            "task-config-param-val-2",
-				}))
-			})
-		})
-	})
-
 	Describe("StaticConfigSource", func() {
 		var (
 			configSource TaskConfigSource

--- a/exec/task_step.go
+++ b/exec/task_step.go
@@ -157,6 +157,11 @@ func (action *TaskStep) Run(ctx context.Context, state RunState) error {
 	repository := state.Artifacts()
 
 	config, err := action.configSource.FetchConfig(repository)
+
+	for _, warning := range action.configSource.Warnings() {
+		fmt.Fprintln(action.delegate.Stderr(), "[WARNING]", warning)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/task.go
+++ b/task.go
@@ -94,7 +94,7 @@ func NewTaskConfig(configBytes []byte) (TaskConfig, error) {
 	return config, nil
 }
 
-func (config TaskConfig) Merge(other TaskConfig) (TaskConfig, error) {
+func (config TaskConfig) Merge(other TaskConfig) (TaskConfig, []string, error) {
 	if other.Platform != "" {
 		config.Platform = other.Platform
 	}
@@ -103,19 +103,15 @@ func (config TaskConfig) Merge(other TaskConfig) (TaskConfig, error) {
 		config.RootfsURI = other.RootfsURI
 	}
 
-	messages := []string{}
+	var warnings []string
 	newParams := config.Params
 
 	for k, v := range other.Params {
 		if _, exists := newParams[k]; exists {
 			newParams[k] = v
 		} else {
-			messages = append(messages, fmt.Sprintf("%s was defined in pipeline but missing from task file", k))
+			warnings = append(warnings, fmt.Sprintf("%s was defined in pipeline but missing from task file", k))
 		}
-	}
-
-	if len(messages) > 0 {
-		return TaskConfig{}, fmt.Errorf("invalid task configuration:\n%s", strings.Join(messages, "\n"))
 	}
 
 	config.Params = newParams
@@ -128,7 +124,7 @@ func (config TaskConfig) Merge(other TaskConfig) (TaskConfig, error) {
 		config.Run = other.Run
 	}
 
-	return config, nil
+	return config, warnings, nil
 }
 
 func (config TaskConfig) Validate() error {

--- a/task_test.go
+++ b/task_test.go
@@ -729,7 +729,7 @@ run: {path: a/file}
 		})
 
 		It("errors if params key in pipeline.yml is not defined in task.yml", func() {
-			_, err := TaskConfig{
+			_, warnings, err := TaskConfig{
 				RootfsURI: "some-image",
 				Params: map[string]string{
 					"FOO": "1",
@@ -741,7 +741,10 @@ run: {path: a/file}
 					"BAZ": "4",
 				},
 			})
-			Expect(err.Error()).To(ContainSubstring("BAZ was defined in pipeline but missing from task file"))
+
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring("BAZ was defined in pipeline but missing from task file"))
+			Expect(err).To(BeNil())
 		})
 
 		It("overrides the platform", func() {


### PR DESCRIPTION
This PR changes an error to a warning for concourse/concourse#2511.

While working on this, I noticed that `StaticConfigSource` and `FileConfigSource` currently return an empty string slice.  I didn't make any changes to them similar to how I changed `MergedConfigSource`, but let me know if I should update them as well for consistency.