### PR TITLE
Remove GC Concurrency limits across worker pool

### DIFF
--- a/atccmd/command.go
+++ b/atccmd/command.go
@@ -132,7 +132,6 @@ type RunCommand struct {
 	GC struct {
 		Interval               time.Duration `long:"interval" default:"30s" description:"Interval on which to perform garbage collection."`
 		OneOffBuildGracePeriod time.Duration `long:"one-off-grace-period" default:"5m" description:"Grace period before reaping one-off task containers"`
-		WorkerConcurrency      int           `long:"worker-concurrency" default:"50" description:"Maximum number of delete operations to have in flight per worker."`
 	} `group:"Garbage Collection" namespace:"gc"`
 
 	BuildTrackerInterval time.Duration `long:"build-tracker-interval" default:"10s" description:"Interval on which to run build tracking."`
@@ -754,14 +753,8 @@ func (cmd *RunCommand) constructBackendMembers(
 					dbContainerRepository,
 					gc.NewWorkerJobRunner(
 						logger.Session("container-collector-worker-job-runner"),
-						workerClient,
+						workerProvider,
 						time.Minute,
-						cmd.GC.WorkerConcurrency,
-						func(logger lager.Logger, workerName string) {
-							metric.GarbageCollectionContainerCollectorJobDropped{
-								WorkerName: workerName,
-							}.Emit(logger)
-						},
 					),
 				),
 				gc.NewResourceConfigCheckSessionCollector(


### PR DESCRIPTION
smaller change for now is to remove guardrails from job runner
but keep its worker sync-ing to keep the list of running workers
up to date.

Worker Pool just calls Worker Provider to get the list of running 
workers, so it can be simplified if we use Worker Provider directly 
instead.