### PR TITLE
Fix Vault retry bug - check for backoff.Stop

### DIFF
--- a/creds/vault/reauther.go
+++ b/creds/vault/reauther.go
@@ -87,7 +87,11 @@ func (ra *ReAuther) authLoop() {
 		for {
 			lease, err := ra.auther.Login()
 			if err != nil {
-				time.Sleep(exp.NextBackOff())
+				nextBackoff := exp.NextBackOff()
+				if nextBackoff == backoff.Stop {
+					nextBackoff = exp.MaxElapsedTime
+				}
+				time.Sleep(nextBackoff)
 				continue
 			}
 
@@ -112,7 +116,11 @@ func (ra *ReAuther) authLoop() {
 
 			lease, err := ra.auther.Renew()
 			if err != nil {
-				time.Sleep(exp.NextBackOff())
+				nextBackoff := exp.NextBackOff()
+				if nextBackoff == backoff.Stop {
+					nextBackoff = exp.MaxElapsedTime
+				}
+				time.Sleep(nextBackoff)
 				continue
 			}
 


### PR DESCRIPTION
If Vault is used but there are errors logging in or renewing a token, there is a case where numerous login/renew requests are made to Vault every second.  This happens when the `--vault-retry-max` interval has been reached.

Vault's `reauther.go` currently uses [`exp.NextBackOff()`](https://github.com/concourse/atc/blob/master/creds/vault/reauther.go#L90) determine the next time to retry a failed `Login` or `Renew`.  However, if `--vault-retry-max` has been reached, `exp.NextBackOff()` returns `backoff.Stop`, which is -1, causing no `sleep` to occur.

This PR checks to see if `backoff.Stop` is returned, and if so, to set the retry interval to `--vault-retry-max`.